### PR TITLE
chore: remove codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,6 @@ jobs:
       - name: Test coverage
         run: pnpm test:coverage
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-
   deploy:
     runs-on: ubuntu-latest
     needs: build-test

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # GLB-only Character Morph Creator
 
 [![CI](https://github.com/beyawnko/Beya_Chara_Studio/actions/workflows/ci.yml/badge.svg)](https://github.com/beyawnko/Beya_Chara_Studio/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/beyawnko/Beya_Chara_Studio/branch/main/graph/badge.svg?token=<CODECOV_TOKEN>)](https://codecov.io/gh/<your-username>/<repo-name>)
 
 Live demo (GitHub Pages): https://beyawnko.github.io/Beya_Chara_Studio/
 
@@ -17,7 +16,6 @@ Live demo (GitHub Pages): https://beyawnko.github.io/Beya_Chara_Studio/
 
 ## CI
 - GitHub Actions (`.github/workflows/ci.yml`) runs lint, unit, coverage, e2e, and deploys Pages on main/master.
-- To enable **Codecov**, add a `CODECOV_TOKEN` secret in your repo settings.
 
 ## Pages base path
 - Vite `base` is controlled by `GITHUB_PAGES_BASE`. CI sets it to `/${repo}/`.


### PR DESCRIPTION
## Summary
- remove Codecov badge from README
- stop uploading coverage to Codecov in CI

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897d5e0475083229fcf0677c49d909c