### PR TITLE
ci: use frozen pnpm lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install
-        run: pnpm install --frozen-lockfile=false
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint
@@ -64,7 +64,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install
-        run: pnpm install --frozen-lockfile=false
+        run: pnpm install --frozen-lockfile
 
       - name: Build (GitHub Pages base)
         run: GITHUB_PAGES_BASE=/${{ github.event.repository.name }}/ pnpm build


### PR DESCRIPTION
## Summary
- use `pnpm install --frozen-lockfile` in CI

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm test`
- `pnpm test:coverage` *(fails: this.resolveReporters is not a function)*
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6897d5f2d1c88322aebbce8da4d77a2c