### PR TITLE
Fix skeleton cloning for GLB export round-trip

### DIFF
--- a/src/lib/exportGLB.ts
+++ b/src/lib/exportGLB.ts
@@ -1,12 +1,14 @@
 import * as THREE from 'three'
 import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js'
+import { clone as cloneSkeleton } from 'three/examples/jsm/utils/SkeletonUtils.js'
 
 import type { LoadedFBX } from '../types'
 
 export async function exportGLBBuffer(asset: LoadedFBX, opts?: { materialAllow?: Set<number> }): Promise<ArrayBuffer> {
   const root = new THREE.Group()
-  const mesh = asset.mesh.clone()
-  mesh.skeleton = asset.mesh.skeleton
+  const mesh = cloneSkeleton(asset.mesh) as THREE.SkinnedMesh
+  // SkeletonUtils.clone() ensures the skeleton references the cloned bones.
+  // Overriding it would break the hierarchy, so only swap in a cloned geometry.
   mesh.geometry = asset.geometry.clone()
 
   if (opts?.materialAllow && Array.isArray(mesh.material)) {

--- a/tests/glb-roundtrip.spec.ts
+++ b/tests/glb-roundtrip.spec.ts
@@ -58,6 +58,6 @@ describe('GLB round-trip', () => {
     expect(g.morphAttributes?.position?.length || 0).toBe(asset.geometry.morphAttributes.position!.length)
     const inMorph = asset.geometry.morphAttributes.position![0] as THREE.BufferAttribute
     const outMorph = g.morphAttributes.position![0]
-    expect(Array.from(outMorph.array)).toEqual(Array.from(inMorph.array))
+    expect(outMorph.array).toEqual(inMorph.array)
   })
 })

--- a/tests/glb-roundtrip.spec.ts
+++ b/tests/glb-roundtrip.spec.ts
@@ -55,7 +55,7 @@ describe('GLB round-trip', () => {
     expect(outPos.count).toBe(inPos.count)
 
     // morph target round-trips
-    expect(g.morphAttributes?.position?.length || 0).toBe(1)
+    expect(g.morphAttributes?.position?.length || 0).toBe(asset.geometry.morphAttributes.position!.length)
     const inMorph = asset.geometry.morphAttributes.position![0] as THREE.BufferAttribute
     const outMorph = g.morphAttributes.position![0]
     expect(Array.from(outMorph.array)).toEqual(Array.from(inMorph.array))


### PR DESCRIPTION
## Summary
- clone skinned meshes with `SkeletonUtils.clone` to ensure valid skeleton nodes in exported GLBs
- add assertions for geometry and morph restoration in round-trip test

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm test`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_6897d8074b9c832294878122f0d9b56e