### PR TITLE
feat: default worker pool size

### DIFF
--- a/tests/pool.spec.ts
+++ b/tests/pool.spec.ts
@@ -1,0 +1,43 @@
+import { it, expect, vi } from 'vitest'
+
+const runMock = vi.fn()
+
+vi.mock('comlink', () => ({
+  wrap: () => ({ diffMorph: runMock })
+}))
+
+it('createPool works without navigator', async () => {
+  runMock.mockResolvedValue({})
+
+  const originalNavigator = globalThis.navigator
+  Object.defineProperty(globalThis, 'navigator', {
+    value: undefined,
+    configurable: true,
+    writable: true
+  })
+
+  const workerInstances: URL[] = []
+  class MockWorker {
+    constructor(_url: URL) {
+      workerInstances.push(_url)
+    }
+    terminate() {}
+  }
+  const originalWorker = globalThis.Worker
+  ;(globalThis as any).Worker = MockWorker as any
+
+  const { createPool } = await import('../src/lib/pool')
+  const pool = createPool(new URL('https://example.com/worker.js'))
+  expect(workerInstances.length).toBe(3)
+  await pool.run('diffMorph', { basePos: new Float32Array(), varPos: new Float32Array() })
+  expect(runMock).toHaveBeenCalled()
+  pool.dispose()
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+    writable: true
+  })
+  ;(globalThis as any).Worker = originalWorker
+  vi.resetModules()
+})


### PR DESCRIPTION
## Summary
- handle missing navigator when computing worker pool size
- cover worker pool creation in a Node-like environment

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm format:check` *(fails: code style issues found in several files)*
- `pnpm test`
- `pnpm test:e2e` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6897df1102f083228139e3f59bf75ef9