### PR TITLE
refactor: dedupe pool worker test setup

### DIFF
--- a/tests/pool.spec.ts
+++ b/tests/pool.spec.ts
@@ -1,6 +1,18 @@
-import { it, expect, vi } from 'vitest'
+import { beforeEach, expect, it, vi } from 'vitest'
 
 const runMock = vi.fn()
+
+const workerInstances: URL[] = []
+class MockWorker {
+  constructor(url: URL) {
+    workerInstances.push(url)
+  }
+  terminate() {}
+}
+
+beforeEach(() => {
+  workerInstances.length = 0
+})
 
 vi.mock('comlink', () => ({
   wrap: () => ({ diffMorph: runMock })
@@ -16,13 +28,6 @@ it('createPool works without navigator', async () => {
     writable: true
   })
 
-  const workerInstances: URL[] = []
-  class MockWorker {
-    constructor(_url: URL) {
-      workerInstances.push(_url)
-    }
-    terminate() {}
-  }
   const originalWorker = globalThis.Worker
   ;(globalThis as any).Worker = MockWorker as any
 
@@ -46,13 +51,6 @@ it('createPool uses default worker count', async () => {
   runMock.mockClear()
   runMock.mockResolvedValue({})
 
-  const workerInstances: URL[] = []
-  class MockWorker {
-    constructor(url: URL) {
-      workerInstances.push(url)
-    }
-    terminate() {}
-  }
   vi.stubGlobal('Worker', MockWorker as any)
   vi.stubGlobal('navigator', {})
 


### PR DESCRIPTION
## Summary
- consolidate pool test mock Worker and instance tracking at module scope
- reset workerInstances via `beforeEach` to keep tests isolated

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm format:check` *(fails: code style issues in existing files)*
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6897e5388fbc8322a135d66955b9776a