### PR TITLE
Dispose worker pools on shutdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,12 +10,27 @@ import { PartTabs } from './components/PartTabs'
 import { RetargetPanel } from './components/RetargetPanel'
 import { SkeletonBadge } from './components/SkeletonBadge'
 import { Viewport } from './components/Viewport'
+import { disposeMorphPool } from './lib/morphs'
+import { disposeRetargetPool } from './lib/retarget'
 import { useCharacterStore } from './state/useCharacterStore'
 
 export default function App() {
   const base = useCharacterStore(s => s.base)
   const variants = useCharacterStore(s => s.variants)
   const activePart = useCharacterStore(s => s.activePart)
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') return
+    const cleanup = () => {
+      disposeMorphPool()
+      disposeRetargetPool()
+    }
+    window.addEventListener('beforeunload', cleanup)
+    return () => {
+      cleanup()
+      window.removeEventListener('beforeunload', cleanup)
+    }
+  }, [])
 
   return (
     <div className="row">

--- a/src/lib/retarget.ts
+++ b/src/lib/retarget.ts
@@ -8,9 +8,17 @@ export type BoneMap = Record<string, string>
 
 const NECK_ALIASES = ['neck_01','neck','J_Neck','UpperChest','upperChest']
 let pool: ReturnType<typeof createPool> | null = null
-function ensurePool() {
+
+export function retargetPool() {
   if (!pool) pool = createPool(new URL('../workers/retarget.worker.ts', import.meta.url))
   return pool
+}
+
+export function disposeRetargetPool() {
+  if (pool) {
+    pool.dispose()
+    pool = null
+  }
 }
 
 export function suggestBoneMap(src: THREE.Skeleton, dst: THREE.Skeleton): BoneMap {
@@ -108,7 +116,7 @@ export async function rebindHeadToBody(head: LoadedFBX, body: LoadedFBX, map: Bo
   }
 
   const skinSrc = skinIndex.array as Uint16Array | Uint32Array
-  const out = await ensurePool().run('remapSkinIndex', {
+  const out = await retargetPool().run('remapSkinIndex', {
     src: skinSrc,
     remap,
     fallback: neckIdx

--- a/tests/pool.spec.ts
+++ b/tests/pool.spec.ts
@@ -28,8 +28,8 @@ it('createPool works without navigator', async () => {
     writable: true
   })
 
-  const originalWorker = globalThis.Worker
-  ;(globalThis as any).Worker = MockWorker as any
+  const originalWorker: typeof Worker = globalThis.Worker
+  ;(globalThis as unknown as { Worker: typeof Worker }).Worker = MockWorker as unknown as typeof Worker
 
   const { createPool } = await import('../src/lib/pool')
   const pool = createPool(new URL('https://example.com/worker.js'))
@@ -43,7 +43,7 @@ it('createPool works without navigator', async () => {
     configurable: true,
     writable: true
   })
-  ;(globalThis as any).Worker = originalWorker
+  ;(globalThis as unknown as { Worker: typeof Worker }).Worker = originalWorker
   vi.resetModules()
 })
 
@@ -51,7 +51,7 @@ it('createPool uses default worker count', async () => {
   runMock.mockClear()
   runMock.mockResolvedValue({})
 
-  vi.stubGlobal('Worker', MockWorker as any)
+  vi.stubGlobal('Worker', MockWorker as unknown as typeof Worker)
   vi.stubGlobal('navigator', {})
 
   const { createPool } = await import('../src/lib/pool')

--- a/tests/worker-disposal.spec.ts
+++ b/tests/worker-disposal.spec.ts
@@ -1,0 +1,23 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+beforeEach(() => {
+  vi.resetModules()
+})
+
+it('disposes morph workers', async () => {
+  const dispose = vi.fn()
+  vi.doMock('../src/lib/pool', () => ({ createPool: () => ({ run: vi.fn(), dispose }) }))
+  const { morphPool, disposeMorphPool } = await import('../src/lib/morphs')
+  morphPool()
+  disposeMorphPool()
+  expect(dispose).toHaveBeenCalled()
+})
+
+it('disposes retarget workers', async () => {
+  const dispose = vi.fn()
+  vi.doMock('../src/lib/pool', () => ({ createPool: () => ({ run: vi.fn(), dispose }) }))
+  const { retargetPool, disposeRetargetPool } = await import('../src/lib/retarget')
+  retargetPool()
+  disposeRetargetPool()
+  expect(dispose).toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- add morph and retarget worker pool cleanup helpers
- dispose pools when app unmounts or window unloads
- test that morph and retarget workers terminate after disposal

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm format:check` (fails: Code style issues found in 13 files)
- `pnpm test`
- `pnpm exec playwright install`
- `pnpm exec playwright install-deps`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6897e779e2fc832281679abeab55c7ae