### PR TITLE
refactor importers and pools

### DIFF
--- a/src/lib/importers.ts
+++ b/src/lib/importers.ts
@@ -7,6 +7,12 @@ import { extractVRMPresetsFromGLTF } from './vrm'
 
 export type AnyAsset = LoadedFBX & { vrmPresets?: string[] }
 
+export function validateTopology(base: THREE.BufferGeometry, geo: THREE.BufferGeometry) {
+  const samePos = base.getAttribute('position').count === geo.getAttribute('position').count
+  const sameIdx = (base.getIndex()?.count ?? 0) === (geo.getIndex()?.count ?? 0)
+  if (!samePos || !sameIdx) throw new Error('Topology mismatch vs base')
+}
+
 function sanitizeSkinned(skinned: THREE.SkinnedMesh) {
   const geo = skinned.geometry.clone()
   if (!geo.getAttribute('position')) throw new Error('Missing positions')
@@ -30,6 +36,7 @@ function firstSkinned(root: THREE.Object3D): THREE.SkinnedMesh | null {
 export async function loadAny(file: File, opts: { asVariantOf?: LoadedFBX } = {}): Promise<AnyAsset> {
   const name = file.name.replace(/\.[^.]+$/, '')
   const ext = file.name.split('.').pop()?.toLowerCase()
+  if (!ext) throw new Error('File has no extension')
   const ab = await file.arrayBuffer()
 
   if (ext === 'fbx') {
@@ -41,11 +48,7 @@ export async function loadAny(file: File, opts: { asVariantOf?: LoadedFBX } = {}
       name, mesh: skinned, geometry: geo, skeleton: skinned.skeleton, bindMatrix: skinned.bindMatrix.clone()
     }
     if (opts.asVariantOf) {
-      const base = opts.asVariantOf.geometry
-      if ((base.getAttribute('position').count !== geo.getAttribute('position').count) ||
-          ((base.getIndex()?.count ?? 0) !== (geo.getIndex()?.count ?? 0))) {
-        throw new Error('Topology mismatch vs base')
-      }
+      validateTopology(opts.asVariantOf.geometry, geo)
     }
     return out
   }
@@ -73,11 +76,7 @@ export async function loadAny(file: File, opts: { asVariantOf?: LoadedFBX } = {}
     }
 
     if (opts.asVariantOf) {
-      const base = opts.asVariantOf.geometry
-      if ((base.getAttribute('position').count !== geo.getAttribute('position').count) ||
-          ((base.getIndex()?.count ?? 0) !== (geo.getIndex()?.count ?? 0))) {
-        throw new Error('Topology mismatch vs base')
-      }
+      validateTopology(opts.asVariantOf.geometry, geo)
     }
     return out
   }

--- a/src/lib/importers.ts
+++ b/src/lib/importers.ts
@@ -8,9 +8,10 @@ import { extractVRMPresetsFromGLTF } from './vrm'
 export type AnyAsset = LoadedFBX & { vrmPresets?: string[] }
 
 export function validateTopology(base: THREE.BufferGeometry, geo: THREE.BufferGeometry) {
-  const samePos = base.getAttribute('position').count === geo.getAttribute('position').count
-  const sameIdx = (base.getIndex()?.count ?? 0) === (geo.getIndex()?.count ?? 0)
-  if (!samePos || !sameIdx) throw new Error('Topology mismatch vs base')
+  const posA = base.getAttribute('position').count, posB = geo.getAttribute('position').count;
+  if (posA !== posB) throw new Error(`Topology mismatch: vertex count ${posA} vs ${posB}`);
+  const idxA = base.getIndex()?.count ?? 0, idxB = geo.getIndex()?.count ?? 0;
+  if (idxA !== idxB) throw new Error(`Topology mismatch: index count ${idxA} vs ${idxB}`);
 }
 
 function sanitizeSkinned(skinned: THREE.SkinnedMesh) {

--- a/src/lib/morphs.ts
+++ b/src/lib/morphs.ts
@@ -2,21 +2,11 @@ import * as THREE from 'three'
 
 import type { LoadedFBX } from '../types'
 import { categorizeMorph } from './categorize'
-import { createPool } from './pool'
+import { createPoolManager } from './poolManager'
 
-let pool: ReturnType<typeof createPool> | null = null
-
-export function morphPool() {
-  if (!pool) pool = createPool(new URL('../workers/morph.worker.ts', import.meta.url))
-  return pool
-}
-
-export function disposeMorphPool() {
-  if (pool) {
-    pool.dispose()
-    pool = null
-  }
-}
+const { getPool, disposePool } = createPoolManager(new URL('../workers/morph.worker.ts', import.meta.url))
+export const morphPool = getPool
+export const disposeMorphPool = disposePool
 
 export async function addVariantAsMorph(base: LoadedFBX, variant: LoadedFBX): Promise<string> {
   const a = base.geometry

--- a/src/lib/poolManager.ts
+++ b/src/lib/poolManager.ts
@@ -1,0 +1,18 @@
+import { createPool } from './pool'
+
+export function createPoolManager(workerUrl: URL) {
+  let pool: ReturnType<typeof createPool> | null = null
+
+  return {
+    getPool: () => {
+      if (!pool) pool = createPool(workerUrl)
+      return pool
+    },
+    disposePool: () => {
+      if (pool) {
+        pool.dispose()
+        pool = null
+      }
+    }
+  }
+}

--- a/src/lib/retarget.ts
+++ b/src/lib/retarget.ts
@@ -1,25 +1,15 @@
 import * as THREE from 'three'
 
 import type { LoadedFBX } from '../types'
-import { createPool } from './pool'
+import { createPoolManager } from './poolManager'
 import { detectProfile,PROFILES } from './skeleton'
 
 export type BoneMap = Record<string, string>
 
 const NECK_ALIASES = ['neck_01','neck','J_Neck','UpperChest','upperChest']
-let pool: ReturnType<typeof createPool> | null = null
-
-export function retargetPool() {
-  if (!pool) pool = createPool(new URL('../workers/retarget.worker.ts', import.meta.url))
-  return pool
-}
-
-export function disposeRetargetPool() {
-  if (pool) {
-    pool.dispose()
-    pool = null
-  }
-}
+const { getPool, disposePool } = createPoolManager(new URL('../workers/retarget.worker.ts', import.meta.url))
+export const retargetPool = getPool
+export const disposeRetargetPool = disposePool
 
 export function suggestBoneMap(src: THREE.Skeleton, dst: THREE.Skeleton): BoneMap {
   const map: BoneMap = {}

--- a/tests/importers.spec.ts
+++ b/tests/importers.spec.ts
@@ -1,0 +1,37 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { validateTopology } from '../src/lib/importers'
+
+describe('validateTopology', () => {
+  it('allows matching position and index counts', () => {
+    const base = new THREE.BufferGeometry()
+    const variant = new THREE.BufferGeometry()
+    const posA = new Float32Array(9)
+    const posB = new Float32Array(9)
+    base.setAttribute('position', new THREE.BufferAttribute(posA, 3))
+    variant.setAttribute('position', new THREE.BufferAttribute(posB, 3))
+    const idx = new THREE.BufferAttribute(new Uint16Array([0,1,2]), 1)
+    base.setIndex(idx)
+    variant.setIndex(idx)
+    expect(() => validateTopology(base, variant)).not.toThrow()
+  })
+
+  it('throws when vertex counts differ', () => {
+    const base = new THREE.BufferGeometry()
+    const variant = new THREE.BufferGeometry()
+    base.setAttribute('position', new THREE.BufferAttribute(new Float32Array(9), 3))
+    variant.setAttribute('position', new THREE.BufferAttribute(new Float32Array(6), 3))
+    expect(() => validateTopology(base, variant)).toThrow()
+  })
+
+  it('throws when index counts differ', () => {
+    const base = new THREE.BufferGeometry()
+    const variant = new THREE.BufferGeometry()
+    const pos = new Float32Array(9)
+    base.setAttribute('position', new THREE.BufferAttribute(pos, 3))
+    variant.setAttribute('position', new THREE.BufferAttribute(pos, 3))
+    base.setIndex(new THREE.BufferAttribute(new Uint16Array([0,1,2]), 1))
+    expect(() => validateTopology(base, variant)).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- factor topology validation into helper and check for missing extensions
- centralize worker pool management with createPoolManager
- add unit tests for topology helper

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm format:check` *(fails: Code style issues found in 13 files. Run Prettier with --write to fix.)*
- `pnpm test`
- `pnpm exec playwright install-deps`
- `pnpm exec playwright install`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6897eab8920083229461061b88f69fb9