### PR TITLE
refactor viewport effects and restrict pool manager

### DIFF
--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -1,6 +1,6 @@
 import { Environment,OrbitControls } from '@react-three/drei'
 import { Canvas } from '@react-three/fiber'
-import React, { useMemo } from 'react'
+import React, { useEffect } from 'react'
 import * as THREE from 'three'
 
 import { useCharacterStore } from '../state/useCharacterStore'
@@ -19,7 +19,7 @@ export function Viewport() {
   const active = activePart==='head' ? head : activePart==='body' ? body : base
   const mesh = active?.mesh
 
-  useMemo(() => {
+  useEffect(() => {
     if (!mesh) return
     mesh.traverse((obj: THREE.Object3D) => {
       if (obj instanceof THREE.Mesh) {
@@ -31,7 +31,7 @@ export function Viewport() {
     })
   }, [mesh])
 
-  useMemo(() => {
+  useEffect(() => {
     if (!mesh) return
     morphKeys.forEach((k, i) => {
       if (mesh.morphTargetInfluences) {
@@ -40,7 +40,7 @@ export function Viewport() {
     })
   }, [mesh, weights, morphKeys])
 
-  useMemo(() => {
+  useEffect(() => {
     if (!mesh) return
     const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
     mats.forEach((m: THREE.Material, i:number) => {

--- a/src/lib/poolManager.ts
+++ b/src/lib/poolManager.ts
@@ -6,7 +6,8 @@ export function createPoolManager(workerUrl: URL) {
   return {
     getPool: () => {
       if (!pool) pool = createPool(workerUrl)
-      return pool
+      const { run } = pool
+      return { run }
     },
     disposePool: () => {
       if (pool) {


### PR DESCRIPTION
## Summary
- replace useMemo hooks in Viewport with useEffect to properly run side-effects
- return run-only proxy from pool manager to prevent accidental disposal

## Testing
- `pnpm format:check`
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f7ee383083229e510627a01752f9