### PR TITLE
fix: dispose materials and type pool manager

### DIFF
--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -21,14 +21,20 @@ export function Viewport() {
 
   useEffect(() => {
     if (!mesh) return
+    const created: THREE.Material[] = []
     mesh.traverse((obj: THREE.Object3D) => {
       if (obj instanceof THREE.Mesh) {
         const m = obj.material
         if (!m || !m.isMeshStandardMaterial) {
-          obj.material = new THREE.MeshStandardMaterial({ metalness: 0.0, roughness: 0.5 })
+          const mat = new THREE.MeshStandardMaterial({ metalness: 0.0, roughness: 0.5 })
+          obj.material = mat
+          created.push(mat)
         }
       }
     })
+    return () => {
+      created.forEach(m => m.dispose())
+    }
   }, [mesh])
 
   useEffect(() => {

--- a/src/lib/poolManager.ts
+++ b/src/lib/poolManager.ts
@@ -4,7 +4,7 @@ export function createPoolManager(workerUrl: URL) {
   let pool: ReturnType<typeof createPool> | null = null
 
   return {
-    getPool: () => {
+    getPool: (): Pick<ReturnType<typeof createPool>, 'run'> => {
       if (!pool) pool = createPool(workerUrl)
       const { run } = pool
       return { run }


### PR DESCRIPTION
## Summary
- dispose MeshStandardMaterials on unmount or mesh change to prevent leaks
- tighten pool manager contract with explicit `run` return type

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm format:check`
- `pnpm test`
- `pnpm test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_689882ca81048322bead18bfefc5109f