### PR TITLE
Add material utilities, PerfHUD overlay, and store persistence fixes

### DIFF
--- a/src/components/ARKitPanel.tsx
+++ b/src/components/ARKitPanel.tsx
@@ -41,13 +41,7 @@ export function ARKitPanel() {
           <div style={{marginTop:8}}>
             <button className="btn" onClick={()=>{
               synthesizeARKitMorphs(asset!)
-              // refresh keys by poking store (rudimentary)
-              const s = useCharacterStore.getState()
-              const dict = (asset!.geometry as THREE.BufferGeometry & { morphTargetsDictionary: { [key: string]: number } }).morphTargetsDictionary || {}
-              const keys = Object.keys(dict)
-              s.morphKeys = keys
-              s.morphWeights = Object.fromEntries(keys.map(k=>[k, s.morphWeights[k] ?? 0]))
-              useCharacterStore.setState({ morphKeys: keys, morphWeights: s.morphWeights })
+              useCharacterStore.getState().refreshMorphKeys(asset!)
             }}>Generate ARKit Morph Targets (procedural subset)</button>
           </div>
 

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -4,6 +4,7 @@ import * as THREE from 'three'
 import { exportGLB, exportGLBBufferCombined } from '../lib/exportGLB'
 import { getMorphMeta } from '../lib/morphs'
 import { useCharacterStore } from '../state/useCharacterStore'
+import { getMaterialSlotId } from '../lib/materials'
 
 export function ExportPanel() {
   const base = useCharacterStore(s => s.base)
@@ -20,7 +21,7 @@ export function ExportPanel() {
     const matArr = Array.isArray(asset.mesh.material) ? asset.mesh.material : [asset.mesh.material]
     const allow = new Set<number>()
     matArr.forEach((m: THREE.Material, i:number) => {
-      const key = `${m?.name || 'mat'}#${i}`
+      const key = getMaterialSlotId(asset.mesh, i)
       const val = assign[key] || 'none'
       if (active==='head' && val==='head') allow.add(i)
       if (active==='body' && val==='body') allow.add(i)
@@ -35,7 +36,7 @@ export function ExportPanel() {
     if (head?.mesh) {
       const arr = Array.isArray(head.mesh.material) ? head.mesh.material : [head.mesh.material]
       arr.forEach((m: THREE.Material,i:number)=>{
-        const key = `${m?.name || 'mat'}#${i}`
+        const key = getMaterialSlotId(head.mesh, i)
         const val = assign[key] || 'none'
         if (val==='head') headAllow.add(i)
       })
@@ -43,7 +44,7 @@ export function ExportPanel() {
     if (body?.mesh) {
       const arr = Array.isArray(body.mesh.material) ? body.mesh.material : [body.mesh.material]
       arr.forEach((m: THREE.Material,i:number)=>{
-        const key = `${m?.name || 'mat'}#${i}`
+        const key = getMaterialSlotId(body.mesh, i)
         const val = assign[key] || 'none'
         if (val==='body') bodyAllow.add(i)
       })

--- a/src/components/MaterialSplitPanel.tsx
+++ b/src/components/MaterialSplitPanel.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 import * as THREE from 'three'
 
 import { useCharacterStore } from '../state/useCharacterStore'
+import { getMaterialSlotId } from '../lib/materials'
 
 type Assign = 'head'|'body'|'none'
 
@@ -18,7 +19,11 @@ export function MaterialSplitPanel() {
   const mats = useMemo(() => {
     if (!mesh) return []
     const m = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
-    return m.map((mat: THREE.Material, idx:number) => ({ index: idx, name: mat?.name || `mat_${idx}` }))
+    return m.map((mat: THREE.Material, idx:number) => ({
+      index: idx,
+      name: mat?.name || `mat_${idx}`,
+      id: getMaterialSlotId(mesh, idx),
+    }))
   }, [mesh])
 
   if (!mesh) return null
@@ -30,8 +35,8 @@ export function MaterialSplitPanel() {
       <table style={{width:'100%', fontSize:12}}>
         <thead><tr><th align="left">Material</th><th>Head</th><th>Body</th><th>None</th></tr></thead>
         <tbody>
-          {mats.map(({index,name}) => {
-            const key = `${name}#${index}`
+          {mats.map(({index,name,id}) => {
+            const key = id
             const val:Assign = assign[key] ?? 'none'
             return (
               <tr key={key}>

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react'
+import { useThree } from '@react-three/fiber'
+
+/** Simple dev-only HUD showing renderer statistics */
+export function PerfHUD() {
+  const { gl } = useThree()
+  const [info, setInfo] = useState(gl.info)
+
+  useEffect(() => {
+    const id = setInterval(() => setInfo({ ...gl.info }), 500)
+    return () => clearInterval(id)
+  }, [gl])
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        background: 'rgba(0,0,0,0.5)',
+        color: 'white',
+        padding: 4,
+        fontSize: 10,
+      }}
+    >
+      <div>Geometries: {info.memory.geometries}</div>
+      <div>Textures: {info.memory.textures}</div>
+    </div>
+  )
+}
+

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -5,9 +5,11 @@ import React, { useState } from 'react'
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
-
-  useFrame((state, delta) => {
-    if (state.clock.elapsedTime % 0.5 < delta) {
+  const UPDATE_INTERVAL = 0.5 // seconds
+  const lastUpdate = React.useRef(0)
+  useFrame((state) => {
+    if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
+      lastUpdate.current = state.clock.elapsedTime
       setInfo({ ...gl.info })
     }
   })

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -6,12 +6,14 @@ const UPDATE_INTERVAL = 0.5 // seconds
 
 export function PerfHUD() {
   const { gl } = useThree()
-  const [memoryInfo, setMemoryInfo] = useState(gl.info.memory)
+  const [geometries, setGeometries] = useState(gl.info.memory.geometries)
+  const [textures, setTextures] = useState(gl.info.memory.textures)
   const lastUpdate = useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setMemoryInfo({ ...gl.info.memory })
+      setGeometries(gl.info.memory.geometries)
+      setTextures(gl.info.memory.textures)
     }
   })
 
@@ -27,8 +29,8 @@ export function PerfHUD() {
         fontSize: 10,
       }}
     >
-      <div>Geometries: {memoryInfo.geometries}</div>
-      <div>Textures: {memoryInfo.textures}</div>
+      <div>Geometries: {geometries}</div>
+      <div>Textures: {textures}</div>
     </div>
   )
 }

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -11,7 +11,7 @@ export function PerfHUD() {
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info })
+      setInfo({ ...gl.info, memory: { ...gl.info.memory } })
     }
   })
 

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,15 +1,16 @@
-import React, { useEffect, useState } from 'react'
-import { useThree } from '@react-three/fiber'
+import { useFrame, useThree } from '@react-three/fiber'
+import React, { useState } from 'react'
 
 /** Simple dev-only HUD showing renderer statistics */
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
 
-  useEffect(() => {
-    const id = setInterval(() => setInfo({ ...gl.info }), 500)
-    return () => clearInterval(id)
-  }, [gl])
+  useFrame((state, delta) => {
+    if (state.clock.elapsedTime % 0.5 < delta) {
+      setInfo({ ...gl.info })
+    }
+  })
 
   return (
     <div

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -11,7 +11,7 @@ export function PerfHUD() {
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info, memory: { ...gl.info.memory } })
+      setInfo({ ...gl.info })
     }
   })
 

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 
 /** Simple dev-only HUD showing renderer statistics */
@@ -6,12 +6,12 @@ const UPDATE_INTERVAL = 0.5 // seconds
 
 export function PerfHUD() {
   const { gl } = useThree()
-  const [info, setInfo] = useState(gl.info)
-  const lastUpdate = React.useRef(0)
+  const [memoryInfo, setMemoryInfo] = useState(gl.info.memory)
+  const lastUpdate = useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info })
+      setMemoryInfo({ ...gl.info.memory })
     }
   })
 
@@ -27,8 +27,8 @@ export function PerfHUD() {
         fontSize: 10,
       }}
     >
-      <div>Geometries: {info.memory.geometries}</div>
-      <div>Textures: {info.memory.textures}</div>
+      <div>Geometries: {memoryInfo.geometries}</div>
+      <div>Textures: {memoryInfo.textures}</div>
     </div>
   )
 }

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,11 +1,12 @@
-import { useFrame, useThree } from '@react-three/fiber'
 import React, { useState } from 'react'
+import { useFrame, useThree } from '@react-three/fiber'
 
 /** Simple dev-only HUD showing renderer statistics */
+const UPDATE_INTERVAL = 0.5 // seconds
+
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
-  const UPDATE_INTERVAL = 0.5 // seconds
   const lastUpdate = React.useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -6,7 +6,8 @@ import * as THREE from 'three'
 import { useCharacterStore } from '../state/useCharacterStore'
 import { BoneHighlighter } from './BoneHighlighter'
 import { HeadTransformGizmo } from './HeadTransformGizmo'
-import { normalizeMeshMaterials } from '../lib/materials'
+import { getMaterialSlotId, normalizeMeshMaterials } from '../lib/materials'
+import { PerfHUD } from './PerfHUD'
 
 export function Viewport() {
   const base = useCharacterStore(s => s.base)
@@ -46,7 +47,7 @@ export function Viewport() {
     if (!mesh) return
     const mats = Array.isArray(mesh.material) ? mesh.material : [mesh.material]
     mats.forEach((m: THREE.Material, i:number) => {
-      const key = `${m?.name || 'mat'}#${i}`
+      const key = getMaterialSlotId(mesh, i)
       const val = assign[key] || 'none'
       let visible = true
       if (activePart==='head') visible = (val === 'head' || val === 'none')

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three'
 
+// FNV-1a variant mixing step for hashing
+const fnv1aMix = (h: number): number =>
+  h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
 /**
  * Upgrade any material to MeshStandardMaterial, preserving basic properties
  * and tracking newly created materials for later disposal.
@@ -39,17 +42,16 @@ function hashGeometry(geom: THREE.BufferGeometry): string {
   const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
   const idx = geom.getIndex()
   let hash = 2166136261
-  const applyMix = (h: number) => h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
   if (pos && pos.array.length >= 3) {
     const arr = pos.array as ArrayLike<number>
     for (let i = 0; i < Math.min(9, arr.length); i++) {
       hash ^= Math.round(arr[i] * 1e3)
-      hash = applyMix(hash)
+      hash = fnv1aMix(hash)
     }
   }
   if (idx) {
     hash ^= idx.count
-    hash = applyMix(hash)
+    hash = fnv1aMix(hash)
   }
   return (hash >>> 0).toString(36)
 }

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 
 // FNV-1a variant mixing step for hashing
 const fnv1aMix = (h: number): number =>
-  h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
+  (h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)) | 0
 /**
  * Upgrade any material to MeshStandardMaterial, preserving basic properties
  * and tracking newly created materials for later disposal.

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -39,16 +39,17 @@ function hashGeometry(geom: THREE.BufferGeometry): string {
   const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
   const idx = geom.getIndex()
   let hash = 2166136261
+  const applyMix = (h: number) => h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
   if (pos && pos.array.length >= 3) {
     const arr = pos.array as ArrayLike<number>
     for (let i = 0; i < Math.min(9, arr.length); i++) {
       hash ^= Math.round(arr[i] * 1e3)
-      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+      hash = applyMix(hash)
     }
   }
   if (idx) {
     hash ^= idx.count
-    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+    hash = applyMix(hash)
   }
   return (hash >>> 0).toString(36)
 }

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -1,0 +1,65 @@
+import * as THREE from 'three'
+
+/**
+ * Upgrade any material to MeshStandardMaterial, preserving basic properties
+ * and tracking newly created materials for later disposal.
+ */
+export function toStandardMaterial(
+  mat: THREE.Material,
+  created: THREE.Material[],
+): THREE.Material {
+  if (mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshPhysicalMaterial) {
+    return mat
+  }
+  const next = new THREE.MeshStandardMaterial()
+  // try to preserve color & map when available
+  const src = mat as THREE.Material & { color?: THREE.Color; map?: THREE.Texture }
+  if (src.color) next.color = src.color.clone()
+  if (src.map) next.map = src.map
+  created.push(next)
+  return next
+}
+
+/**
+ * Normalise a mesh's material(s) to MeshStandardMaterial variants.
+ * Any newly created materials are pushed to `created` for disposal.
+ */
+export function normalizeMeshMaterials(
+  mesh: THREE.Mesh,
+  created: THREE.Material[],
+): void {
+  if (Array.isArray(mesh.material)) {
+    mesh.material = mesh.material.map(m => (m ? toStandardMaterial(m, created) : m))
+  } else if (mesh.material) {
+    mesh.material = toStandardMaterial(mesh.material, created)
+  }
+}
+
+function hashGeometry(geom: THREE.BufferGeometry): string {
+  const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
+  const idx = geom.getIndex()
+  let hash = 2166136261
+  if (pos && pos.array.length >= 3) {
+    const arr = pos.array as ArrayLike<number>
+    for (let i = 0; i < Math.min(9, arr.length); i++) {
+      hash ^= Math.round(arr[i] * 1e3)
+      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+    }
+  }
+  if (idx) {
+    hash ^= idx.count
+    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+  }
+  return (hash >>> 0).toString(36)
+}
+
+/**
+ * Generate a deterministic ID for a material slot on a mesh based on its
+ * geometry contents and the material index. This remains stable across reloads
+ * and multiple imports of identical geometry.
+ */
+export function getMaterialSlotId(mesh: THREE.Mesh, index: number): string {
+  const geom = mesh.geometry as THREE.BufferGeometry
+  return `${hashGeometry(geom)}:${index}`
+}
+

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -136,5 +136,5 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   }
 }), {
   name:'char-morphs',
-  partialize: s => ({ materialAssign: s.materialAssign, boneMap: s.boneMap, headOffset: s.headOffset }),
+  partialize: s => ({ materialAssign: s.materialAssign, boneMap: s.boneMap, headOffset: s.headOffset, morphWeights: s.morphWeights }),
 }))

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import * as THREE from 'three'
 
 import { loadAny } from '../lib/importers'
 import { addVariantAsMorph } from '../lib/morphs'
@@ -30,6 +31,7 @@ type State = {
   setBoneMap: (src:string, dst:string)=>void
   setHeadOffset: (o: Partial<{ position: Vec3, rotation: Vec3, scale: number }>)=>void
   setSelectedBones: (src?:string, dst?:string)=>void
+  refreshMorphKeys: (asset: AnyAsset)=>void
   clearErrors: ()=>void
 }
 
@@ -58,6 +60,15 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
     scale: o.scale ?? s.headOffset.scale
   }})),
   setSelectedBones: (src, dst) => set({ selSrcBone: src, selDstBone: dst }),
+  refreshMorphKeys: (asset) => set(s => {
+    const dict = (asset.geometry as THREE.BufferGeometry & { morphTargetsDictionary?: Record<string, number> }).morphTargetsDictionary || {}
+    const keys = Object.keys(dict)
+    const weights = keys.reduce<Record<string, number>>((acc, k) => {
+      acc[k] = s.morphWeights[k] ?? 0
+      return acc
+    }, {})
+    return { morphKeys: keys, morphWeights: weights }
+  }),
   onFiles: async (kind, files) => {
     const pushErr = (msg:string) => set(s => ({ errors: [...s.errors, msg] }))
     try {
@@ -126,4 +137,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
       pushErr(msg)
     }
   }
-}), { name:'char-morphs' }))
+}), {
+  name:'char-morphs',
+  partialize: s => ({ materialAssign: s.materialAssign, boneMap: s.boneMap, headOffset: s.headOffset }),
+}))

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -63,10 +63,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   refreshMorphKeys: (asset) => set(s => {
     const dict = (asset.geometry as THREE.BufferGeometry & { morphTargetsDictionary?: Record<string, number> }).morphTargetsDictionary || {}
     const keys = Object.keys(dict)
-    const weights = keys.reduce<Record<string, number>>((acc, k) => {
-      acc[k] = s.morphWeights[k] ?? 0
-      return acc
-    }, {})
+    const weights = Object.fromEntries(keys.map(k => [k, s.morphWeights[k] ?? 0]))
     return { morphKeys: keys, morphWeights: weights }
   }),
   onFiles: async (kind, files) => {

--- a/tests/materials.spec.ts
+++ b/tests/materials.spec.ts
@@ -1,0 +1,50 @@
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
+
+import { getMaterialSlotId, normalizeMeshMaterials } from '../src/lib/materials'
+
+describe('material helpers', () => {
+  it('leaves MeshStandardMaterial untouched', () => {
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshStandardMaterial())
+    const created: THREE.Material[] = []
+    normalizeMeshMaterials(mesh, created)
+    expect(created.length).toBe(0)
+    expect(mesh.material).toBeInstanceOf(THREE.MeshStandardMaterial)
+  })
+
+  it('upgrades basic material preserving color', () => {
+    const mat = new THREE.MeshBasicMaterial({ color: 'red' })
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry(), mat)
+    const created: THREE.Material[] = []
+    normalizeMeshMaterials(mesh, created)
+    expect(created.length).toBe(1)
+    const m = mesh.material as THREE.MeshStandardMaterial
+    expect(m.color.getStyle()).toBe('rgb(255,0,0)')
+  })
+
+  it('handles array without collapsing', () => {
+    const mats: THREE.Material[] = [new THREE.MeshBasicMaterial(), new THREE.MeshStandardMaterial()]
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry(), mats)
+    const created: THREE.Material[] = []
+    normalizeMeshMaterials(mesh, created)
+    const arr = mesh.material as THREE.Material[]
+    expect(arr).toHaveLength(2)
+    expect(arr[1]).toBeInstanceOf(THREE.MeshStandardMaterial)
+    expect(created.length).toBe(1)
+  })
+
+  it('generates stable material slot ids', () => {
+    const geom = new THREE.BoxGeometry(1, 1, 1)
+    const meshA = new THREE.Mesh(geom, [new THREE.MeshStandardMaterial()])
+    const meshB = new THREE.Mesh(geom.clone(), [new THREE.MeshStandardMaterial()])
+    const idA = getMaterialSlotId(meshA, 0)
+    const idA2 = getMaterialSlotId(meshA, 0)
+    const idB = getMaterialSlotId(meshB, 0)
+    expect(idA).toBe(idA2)
+    expect(idA).toBe(idB)
+    const geom2 = new THREE.BoxGeometry(2, 1, 1)
+    const meshC = new THREE.Mesh(geom2, [new THREE.MeshStandardMaterial()])
+    expect(getMaterialSlotId(meshC, 0)).not.toBe(idA)
+  })
+})
+

--- a/tests/perfHUD.spec.tsx
+++ b/tests/perfHUD.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useThree: () => ({ gl: { info: { memory: { geometries: 1, textures: 2 } } } }),
+}))
+
+vi.mock('../src/state/useCharacterStore', () => {
+  const state = {
+    base: null,
+    head: null,
+    body: null,
+    activePart: 'base',
+    morphWeights: {} as Record<string, number>,
+    morphKeys: [] as string[],
+    materialAssign: {} as Record<string, 'head'|'body'|'none'>,
+  }
+  return {
+    useCharacterStore: (sel?: (s: typeof state) => unknown) => (sel ? sel(state) : state),
+  }
+})
+
+import { Viewport } from '../src/components/Viewport'
+
+describe('PerfHUD overlay', () => {
+  it('renders in development mode', () => {
+    vi.stubEnv('DEV', 'true')
+    const html = renderToStaticMarkup(<Viewport />)
+    expect(html).toContain('Geometries')
+    vi.unstubAllEnvs()
+  })
+})
+

--- a/tests/store.spec.ts
+++ b/tests/store.spec.ts
@@ -1,12 +1,46 @@
-import { describe, expect,it } from 'vitest'
+import * as THREE from 'three'
+import { describe, expect, it } from 'vitest'
 
+import { getMaterialSlotId } from '../src/lib/materials'
 import { useCharacterStore } from '../src/state/useCharacterStore'
+import type { AnyAsset } from '../src/types'
 
-describe('material assignment store', () => {
+describe('character store', () => {
   it('sets material assignment entries', () => {
+    const mesh = new THREE.Mesh(new THREE.BufferGeometry(), new THREE.MeshStandardMaterial())
+    const key = getMaterialSlotId(mesh, 0)
     const set = useCharacterStore.getState().setMaterialAssign
-    set('mat#0','head')
-    const val = useCharacterStore.getState().materialAssign['mat#0']
+    set(key, 'head')
+    const val = useCharacterStore.getState().materialAssign[key]
     expect(val).toBe('head')
+  })
+
+  it('refreshMorphKeys updates state immutably', () => {
+    useCharacterStore.setState({ morphKeys: ['A'], morphWeights: { A: 0 } })
+    const geom = new THREE.BufferGeometry() as THREE.BufferGeometry & {
+      morphTargetsDictionary?: Record<string, number>
+    }
+    geom.morphTargetsDictionary = { A: 0, B: 1 }
+    const asset: AnyAsset = { geometry: geom } as unknown as AnyAsset
+    useCharacterStore.getState().refreshMorphKeys(asset)
+    const { morphKeys, morphWeights } = useCharacterStore.getState()
+    expect(morphKeys).toEqual(['A', 'B'])
+    expect(morphWeights).toEqual({ A: 0, B: 0 })
+  })
+
+  it('persists only lightweight fields', () => {
+    localStorage.clear()
+    useCharacterStore.setState({
+      materialAssign: { foo: 'head' },
+      boneMap: { a: 'b' },
+      headOffset: { position: { x: 1, y: 2, z: 3 }, rotation: { x: 0, y: 0, z: 0 }, scale: 1 },
+      base: { mesh: {} as unknown as THREE.Mesh } as unknown as AnyAsset,
+    })
+    const raw = localStorage.getItem('char-morphs')!
+    const stored = JSON.parse(raw).state
+    expect(stored).toHaveProperty('materialAssign')
+    expect(stored).toHaveProperty('boneMap')
+    expect(stored).toHaveProperty('headOffset')
+    expect(stored).not.toHaveProperty('base')
   })
 })


### PR DESCRIPTION
## Summary
- normalize imported materials and generate stable material slot IDs
- add development PerfHUD overlay and integrate with Viewport
- refactor morph key refresh and restrict persisted Zustand fields

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint` *(warnings: import order, unused vars)*
- `pnpm format:check` *(failed: code style issues in repository)*
- `pnpm test`
- `pnpm test:e2e` *(failed: Playwright browsers/dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a516cdcc88322848a4b42e9889c5c