### PR TITLE
refactor: dedupe hash mix and simplify weight mapping

### DIFF
--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -1,5 +1,8 @@
 import * as THREE from 'three'
 
+// FNV-1a variant mixing step for hashing
+const fnv1aMix = (h: number): number =>
+  h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
 /**
  * Upgrade any material to MeshStandardMaterial, preserving basic properties
  * and tracking newly created materials for later disposal.
@@ -39,17 +42,16 @@ function hashGeometry(geom: THREE.BufferGeometry): string {
   const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
   const idx = geom.getIndex()
   let hash = 2166136261
-  const applyMix = (h: number) => h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
   if (pos && pos.array.length >= 3) {
     const arr = pos.array as ArrayLike<number>
     for (let i = 0; i < Math.min(9, arr.length); i++) {
       hash ^= Math.round(arr[i] * 1e3)
-      hash = applyMix(hash)
+      hash = fnv1aMix(hash)
     }
   }
   if (idx) {
     hash ^= idx.count
-    hash = applyMix(hash)
+    hash = fnv1aMix(hash)
   }
   return (hash >>> 0).toString(36)
 }

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 
 // FNV-1a variant mixing step for hashing
 const fnv1aMix = (h: number): number =>
-  h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
+  (h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)) | 0
 /**
  * Upgrade any material to MeshStandardMaterial, preserving basic properties
  * and tracking newly created materials for later disposal.

--- a/src/lib/materials.ts
+++ b/src/lib/materials.ts
@@ -39,16 +39,17 @@ function hashGeometry(geom: THREE.BufferGeometry): string {
   const pos = geom.getAttribute('position') as THREE.BufferAttribute | undefined
   const idx = geom.getIndex()
   let hash = 2166136261
+  const applyMix = (h: number) => h + (h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24)
   if (pos && pos.array.length >= 3) {
     const arr = pos.array as ArrayLike<number>
     for (let i = 0; i < Math.min(9, arr.length); i++) {
       hash ^= Math.round(arr[i] * 1e3)
-      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+      hash = applyMix(hash)
     }
   }
   if (idx) {
     hash ^= idx.count
-    hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+    hash = applyMix(hash)
   }
   return (hash >>> 0).toString(36)
 }

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -63,10 +63,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   refreshMorphKeys: (asset) => set(s => {
     const dict = (asset.geometry as THREE.BufferGeometry & { morphTargetsDictionary?: Record<string, number> }).morphTargetsDictionary || {}
     const keys = Object.keys(dict)
-    const weights = keys.reduce<Record<string, number>>((acc, k) => {
-      acc[k] = s.morphWeights[k] ?? 0
-      return acc
-    }, {})
+    const weights = Object.fromEntries(keys.map(k => [k, s.morphWeights[k] ?? 0]))
     return { morphKeys: keys, morphWeights: weights }
   }),
   onFiles: async (kind, files) => {


### PR DESCRIPTION
## Summary
- extract helper to avoid duplicated hash mixing in `hashGeometry`
- derive morph weights via `Object.fromEntries`

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm format:check` (fails: Code style issues found in 13 files)
- `pnpm test`
- `pnpm exec playwright install`
- `pnpm exec playwright install-deps`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689ac87fbe808322bd03b299d42a905c