### PR TITLE
refactor(perf): refresh HUD via useFrame

### DIFF
--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -5,9 +5,11 @@ import React, { useState } from 'react'
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
-
-  useFrame((state, delta) => {
-    if (state.clock.elapsedTime % 0.5 < delta) {
+  const UPDATE_INTERVAL = 0.5 // seconds
+  const lastUpdate = React.useRef(0)
+  useFrame((state) => {
+    if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
+      lastUpdate.current = state.clock.elapsedTime
       setInfo({ ...gl.info })
     }
   })

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -11,7 +11,7 @@ export function PerfHUD() {
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info })
+      setInfo({ ...gl.info, memory: { ...gl.info.memory } })
     }
   })
 

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,15 +1,16 @@
-import React, { useEffect, useState } from 'react'
-import { useThree } from '@react-three/fiber'
+import { useFrame, useThree } from '@react-three/fiber'
+import React, { useState } from 'react'
 
 /** Simple dev-only HUD showing renderer statistics */
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
 
-  useEffect(() => {
-    const id = setInterval(() => setInfo({ ...gl.info }), 500)
-    return () => clearInterval(id)
-  }, [gl])
+  useFrame((state, delta) => {
+    if (state.clock.elapsedTime % 0.5 < delta) {
+      setInfo({ ...gl.info })
+    }
+  })
 
   return (
     <div

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -11,7 +11,7 @@ export function PerfHUD() {
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info, memory: { ...gl.info.memory } })
+      setInfo({ ...gl.info })
     }
   })
 

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,11 +1,12 @@
-import { useFrame, useThree } from '@react-three/fiber'
 import React, { useState } from 'react'
+import { useFrame, useThree } from '@react-three/fiber'
 
 /** Simple dev-only HUD showing renderer statistics */
+const UPDATE_INTERVAL = 0.5 // seconds
+
 export function PerfHUD() {
   const { gl } = useThree()
   const [info, setInfo] = useState(gl.info)
-  const UPDATE_INTERVAL = 0.5 // seconds
   const lastUpdate = React.useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {


### PR DESCRIPTION
## Summary
- use @react-three/fiber `useFrame` to refresh PerfHUD stats on the render loop

## Testing
- `ESLINT_USE_FLAT_CONFIG=false pnpm lint`
- `pnpm format:check` *(fails: Code style issues found in 13 files)*
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689acfbd7bb483229ab87fd73579faba