### PR TITLE
refactor: narrow PerfHUD state to memory info

### DIFF
--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -6,12 +6,14 @@ const UPDATE_INTERVAL = 0.5 // seconds
 
 export function PerfHUD() {
   const { gl } = useThree()
-  const [memoryInfo, setMemoryInfo] = useState(gl.info.memory)
+  const [geometries, setGeometries] = useState(gl.info.memory.geometries)
+  const [textures, setTextures] = useState(gl.info.memory.textures)
   const lastUpdate = useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setMemoryInfo({ ...gl.info.memory })
+      setGeometries(gl.info.memory.geometries)
+      setTextures(gl.info.memory.textures)
     }
   })
 
@@ -27,8 +29,8 @@ export function PerfHUD() {
         fontSize: 10,
       }}
     >
-      <div>Geometries: {memoryInfo.geometries}</div>
-      <div>Textures: {memoryInfo.textures}</div>
+      <div>Geometries: {geometries}</div>
+      <div>Textures: {textures}</div>
     </div>
   )
 }

--- a/src/components/PerfHUD.tsx
+++ b/src/components/PerfHUD.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 
 /** Simple dev-only HUD showing renderer statistics */
@@ -6,12 +6,12 @@ const UPDATE_INTERVAL = 0.5 // seconds
 
 export function PerfHUD() {
   const { gl } = useThree()
-  const [info, setInfo] = useState(gl.info)
-  const lastUpdate = React.useRef(0)
+  const [memoryInfo, setMemoryInfo] = useState(gl.info.memory)
+  const lastUpdate = useRef(0)
   useFrame((state) => {
     if (state.clock.elapsedTime - lastUpdate.current > UPDATE_INTERVAL) {
       lastUpdate.current = state.clock.elapsedTime
-      setInfo({ ...gl.info })
+      setMemoryInfo({ ...gl.info.memory })
     }
   })
 
@@ -27,8 +27,8 @@ export function PerfHUD() {
         fontSize: 10,
       }}
     >
-      <div>Geometries: {info.memory.geometries}</div>
-      <div>Textures: {info.memory.textures}</div>
+      <div>Geometries: {memoryInfo.geometries}</div>
+      <div>Textures: {memoryInfo.textures}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- store only `gl.info.memory` in PerfHUD state for more robust updates

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm format:check` *(fails: code style issues found in 13 files)*
- `pnpm test`
- `pnpm test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_689bdd8fce44832286d3178a6b7a768c