### PR TITLE
feat: add initial VRM loader support

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
+    "@pixiv/three-vrm": "^3.4.2",
     "@react-three/drei": "^9.111.3",
     "@react-three/fiber": "^8.17.10",
     "comlink": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@pixiv/three-vrm':
+        specifier: ^3.4.2
+        version: 3.4.2(three@0.166.1)
       '@react-three/drei':
         specifier: ^9.111.3
         version: 9.122.0(@react-three/fiber@8.18.0(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1))(@types/react@18.3.23)(@types/three@0.166.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.166.1)(use-sync-external-store@1.5.0(react@18.3.1))
@@ -441,6 +444,62 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pixiv/three-vrm-core@3.4.2':
+    resolution: {integrity: sha512-ucdf5hzCcgc421UVjhBQK3VpnodDdOJFf/3RY9glD4RLj0iURZ4hTd4zKXhSITKSS/IisRgU4J2lDhtU0u7e3g==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-hdr-emissive-multiplier@3.4.2':
+    resolution: {integrity: sha512-OuDBao5GRfAefPXK4w4su2AzM/yGvqYYfZQaQryyhSzQbA1UV8EpW4xfrWjdGJ4HiD98L9hVeObZrjZyq2ZVkA==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-mtoon@3.4.2':
+    resolution: {integrity: sha512-UH0ZwF3oWyxr+FwIc4CBdBKsGKfPsaDPt8/lplX+D8oExNZ4eKBSKUaNytV6XhxgWR5a0ZPoZJUzvsCzjv0BPQ==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-materials-v0compat@3.4.2':
+    resolution: {integrity: sha512-h1E/CB3h3f3iK0QnzzfeBy4C2GiiSkSf6q4OSYg26Qnyvl8iCPduqukm85yD5xuyDU3i1KzimuWj0n1Ah3s6kw==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-node-constraint@3.4.2':
+    resolution: {integrity: sha512-KjkvsZv91naCkblOttM46JdJP2UdKCd+fAxewnVAc+FWkS5qUA1fiKZhWz06JuO1yMVMY3/OohnIlDfRGtdq6A==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm-springbone@3.4.2':
+    resolution: {integrity: sha512-4IUOHehnWkg2ZhipCGpSppB7lfR+/GuLVLp42N5jQi6Tf3keAm/tXwDeGgJO2o9AgcDW2Gq3/MFxkcSfvojKCw==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/three-vrm@3.4.2':
+    resolution: {integrity: sha512-Q3WLZ2Keh3y1GOhxWFieQCXsi+O9cGoPJD7GxQI6VJIEGuWXF0ghPND7RNUd1/AM2/Al7ChuWyaqyGq7j5/0/w==}
+    peerDependencies:
+      three: '>=0.137'
+
+  '@pixiv/types-vrm-0.0@3.4.2':
+    resolution: {integrity: sha512-Y8jELwRGYW5GkO0Q9SQ2XOwGHgbKiLB3bRedpRELCEJVki2vWWkNoK8MqyuXmBEk2pQdaU5YDJ1mDpdCNVaIDA==}
+
+  '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0@3.4.2':
+    resolution: {integrity: sha512-kqo08aM9mPq9c9sfq8x+TxhrhuF41aaCeOoDAcSfwcOQgXrZt6ZFbyiiI9ViMpeuCZ8bSjjN6f5Opf3BwbYMLQ==}
+
+  '@pixiv/types-vrmc-materials-mtoon-1.0@3.4.2':
+    resolution: {integrity: sha512-VVcY7SniFh+wj0fNA/MDWr7ST6AWoaKtlxzC/ZyQd28zxjRgGbe40OGdref64rBxGwIV8JfBXgtYUxrJ2BN5DQ==}
+
+  '@pixiv/types-vrmc-node-constraint-1.0@3.4.2':
+    resolution: {integrity: sha512-DIkmUxeyaAl6iMiH20ug+ns2trnQPvi5lU0Hf3r/g4Ikq+8WRDcX3pggG1Uihr6xAy4S4lc7u5dS5lLDrAEsbw==}
+
+  '@pixiv/types-vrmc-springbone-1.0@3.4.2':
+    resolution: {integrity: sha512-xbwsSPl31vltmYW9ADX6DxgnGZcXhhsqkcY4Jr6N0xCxH+H1V0qv5vNhN/+ntBMccQul35CtzNpXZohJ5zB1wA==}
+
+  '@pixiv/types-vrmc-springbone-extended-collider-1.0@3.4.2':
+    resolution: {integrity: sha512-4leeV4KmG8cw98L0vAVrv5XsyGmIEr4iTr5rZ2dTOW2KJjoA458mBWnlKImj2n6bVCoqgExvt6IIi2AFnJgWjA==}
+
+  '@pixiv/types-vrmc-vrm-1.0@3.4.2':
+    resolution: {integrity: sha512-AcbcDDtPevbmds2N7HUfPb/eKbMlbDaS4VADUNC2uO4pQDHa4vi1gDDxneYNFq4htQ2VUco9Yhqr5idp2MofOg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -2697,6 +2756,65 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@pixiv/three-vrm-core@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.4.2
+      '@pixiv/types-vrmc-vrm-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm-materials-hdr-emissive-multiplier@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm-materials-mtoon@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.4.2
+      '@pixiv/types-vrmc-materials-mtoon-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm-materials-v0compat@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.4.2
+      '@pixiv/types-vrmc-materials-mtoon-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm-node-constraint@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrmc-node-constraint-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm-springbone@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/types-vrm-0.0': 3.4.2
+      '@pixiv/types-vrmc-springbone-1.0': 3.4.2
+      '@pixiv/types-vrmc-springbone-extended-collider-1.0': 3.4.2
+      three: 0.166.1
+
+  '@pixiv/three-vrm@3.4.2(three@0.166.1)':
+    dependencies:
+      '@pixiv/three-vrm-core': 3.4.2(three@0.166.1)
+      '@pixiv/three-vrm-materials-hdr-emissive-multiplier': 3.4.2(three@0.166.1)
+      '@pixiv/three-vrm-materials-mtoon': 3.4.2(three@0.166.1)
+      '@pixiv/three-vrm-materials-v0compat': 3.4.2(three@0.166.1)
+      '@pixiv/three-vrm-node-constraint': 3.4.2(three@0.166.1)
+      '@pixiv/three-vrm-springbone': 3.4.2(three@0.166.1)
+      three: 0.166.1
+
+  '@pixiv/types-vrm-0.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-materials-mtoon-1.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-node-constraint-1.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-springbone-1.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-springbone-extended-collider-1.0@3.4.2': {}
+
+  '@pixiv/types-vrmc-vrm-1.0@3.4.2': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true

--- a/src/components/Viewport.tsx
+++ b/src/components/Viewport.tsx
@@ -1,6 +1,7 @@
-import { Environment,OrbitControls } from '@react-three/drei'
-import { Canvas } from '@react-three/fiber'
-import { useEffect } from 'react'
+import type { VRM } from '@pixiv/three-vrm'
+import { Environment, OrbitControls } from '@react-three/drei'
+import { Canvas, useFrame } from '@react-three/fiber'
+import { useEffect, useRef } from 'react'
 import * as THREE from 'three'
 
 import { getMaterialSlotId, normalizeMeshMaterials } from '../lib/materials'
@@ -20,6 +21,15 @@ export function Viewport() {
 
   const active = activePart==='head' ? head : activePart==='body' ? body : base
   const mesh = active?.mesh
+  const vrmRef = useRef<VRM | null>(null)
+
+  useEffect(() => {
+    vrmRef.current = active?.vrm ?? null
+  }, [active])
+
+  useFrame((_, delta) => {
+    vrmRef.current?.update(delta)
+  })
 
   useEffect(() => {
     if (!mesh) return

--- a/src/lib/importers.ts
+++ b/src/lib/importers.ts
@@ -1,7 +1,7 @@
 import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm'
 import * as THREE from 'three'
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js'
-import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 
 import type { AnyAsset, LoadedFBX } from '../types'
 import { extractVRMPresetsFromGLTF } from './vrm'
@@ -56,9 +56,7 @@ export async function loadAny(file: File, opts: { asVariantOf?: LoadedFBX } = {}
   if (ext === 'glb' || ext === 'gltf' || ext === 'vrm') {
     const loader = new GLTFLoader()
     loader.register((parser) => new VRMLoaderPlugin(parser))
-    const gltf = await new Promise<GLTF>((resolve, reject) => {
-      loader.parse(ab, '/', resolve, reject)
-    })
+    const gltf = await loader.parseAsync(ab, '/')
     const vrm = gltf.userData?.vrm
     if (vrm) VRMUtils.rotateVRM0(vrm)
     const root = gltf.scene

--- a/src/lib/importers.ts
+++ b/src/lib/importers.ts
@@ -1,11 +1,10 @@
+import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm'
 import * as THREE from 'three'
 import { FBXLoader } from 'three/examples/jsm/loaders/FBXLoader.js'
-import { GLTF,GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
 
-import type { LoadedFBX } from '../types'
+import type { AnyAsset, LoadedFBX } from '../types'
 import { extractVRMPresetsFromGLTF } from './vrm'
-
-export type AnyAsset = LoadedFBX & { vrmPresets?: string[] }
 
 export function validateTopology(base: THREE.BufferGeometry, geo: THREE.BufferGeometry) {
   const posA = base.getAttribute('position').count, posB = geo.getAttribute('position').count;
@@ -56,22 +55,30 @@ export async function loadAny(file: File, opts: { asVariantOf?: LoadedFBX } = {}
 
   if (ext === 'glb' || ext === 'gltf' || ext === 'vrm') {
     const loader = new GLTFLoader()
+    loader.register((parser) => new VRMLoaderPlugin(parser))
     const gltf = await new Promise<GLTF>((resolve, reject) => {
       loader.parse(ab, '/', resolve, reject)
     })
+    const vrm = gltf.userData?.vrm
+    if (vrm) VRMUtils.rotateVRM0(vrm)
     const root = gltf.scene
     const sk = firstSkinned(root)
     if (!sk) throw new Error('No SkinnedMesh found in GLTF/VRM')
 
     const { skinned, geo } = sanitizeSkinned(sk)
     const out: AnyAsset = {
-      name, mesh: skinned, geometry: geo, skeleton: skinned.skeleton, bindMatrix: skinned.bindMatrix.clone()
+      name,
+      mesh: skinned,
+      geometry: geo,
+      skeleton: skinned.skeleton,
+      bindMatrix: skinned.bindMatrix.clone(),
+      vrm,
     }
 
     // VRM preset extraction (VRM 0.x "VRM" or 1.0 "VRMC_vrm")
     try {
       const presets = extractVRMPresetsFromGLTF(gltf)
-      if (presets?.length) (out as AnyAsset).vrmPresets = presets
+      if (presets?.length) out.vrmPresets = presets
     } catch {
       // ignore errors, not all GLTFs are VRMs
     }

--- a/src/lib/loadFBX.ts
+++ b/src/lib/loadFBX.ts
@@ -1,5 +1,4 @@
-import type { LoadedFBX } from '../types'
-import type { AnyAsset } from './importers'
+import type { AnyAsset, LoadedFBX } from '../types'
 import { loadAny } from './importers'
 
 type Opts = { asVariantOf?: LoadedFBX }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { VRM } from '@pixiv/three-vrm'
 import * as THREE from 'three'
 
 export type LoadedFBX = {
@@ -9,3 +10,5 @@ export type LoadedFBX = {
   head?: THREE.SkinnedMesh | null
   body?: THREE.SkinnedMesh | null
 }
+
+export type AnyAsset = LoadedFBX & { vrm?: VRM, vrmPresets?: string[] }

--- a/tests/importers-vrm.spec.ts
+++ b/tests/importers-vrm.spec.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs'
+import { dirname, resolve } from 'path'
+import { fileURLToPath } from 'url'
+import { describe, expect, it } from 'vitest'
+
+import { loadAny } from '../src/lib/importers'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+function fileFromPath(p: string, name: string) {
+  const buf = readFileSync(resolve(__dirname, p))
+  return new File([buf], name)
+}
+
+describe('VRM loader', () => {
+  it.skip('loads and orients VRM model', async () => {
+    const asset = await loadAny(fileFromPath('assets/VRM1.vrm', 'VRM1.vrm'))
+    expect(asset.vrm).toBeTruthy()
+    expect(asset.vrm?.meta?.specVersion?.startsWith('1')).toBe(true)
+    expect(Math.abs(asset.vrm?.scene.rotation.y ?? 0)).toBeLessThan(1e-5)
+  }, 20000)
+})

--- a/tests/importers-vrm.spec.ts
+++ b/tests/importers-vrm.spec.ts
@@ -1,22 +1,44 @@
-import { readFileSync } from 'fs'
-import { dirname, resolve } from 'path'
-import { fileURLToPath } from 'url'
-import { describe, expect, it } from 'vitest'
+import { type VRM, VRMUtils } from '@pixiv/three-vrm'
+import * as THREE from 'three'
+import { type GLTF, GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js'
+import { describe, expect, it, vi } from 'vitest'
 
 import { loadAny } from '../src/lib/importers'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-function fileFromPath(p: string, name: string) {
-  const buf = readFileSync(resolve(__dirname, p))
-  return new File([buf], name)
-}
-
 describe('VRM loader', () => {
-  it.skip('loads and orients VRM model', async () => {
-    const asset = await loadAny(fileFromPath('assets/VRM1.vrm', 'VRM1.vrm'))
-    expect(asset.vrm).toBeTruthy()
-    expect(asset.vrm?.meta?.specVersion?.startsWith('1')).toBe(true)
-    expect(Math.abs(asset.vrm?.scene.rotation.y ?? 0)).toBeLessThan(1e-5)
-  }, 20000)
+  it('loads and orients VRM0 model', async () => {
+    const vrmScene = new THREE.Group()
+    vrmScene.rotation.y = Math.PI
+    const geo = new THREE.BufferGeometry()
+    geo.setAttribute('position', new THREE.Float32BufferAttribute([0, 0, 0], 3))
+    geo.setAttribute('normal', new THREE.Float32BufferAttribute([0, 1, 0], 3))
+    geo.setAttribute('skinIndex', new THREE.Uint16BufferAttribute([0], 1))
+    geo.setAttribute('skinWeight', new THREE.Float32BufferAttribute([1], 1))
+    const bone = new THREE.Bone()
+    const skeleton = new THREE.Skeleton([bone])
+    const skinned = new THREE.SkinnedMesh(geo, new THREE.MeshBasicMaterial())
+    skinned.add(bone)
+    skinned.bind(skeleton)
+    vrmScene.add(skinned)
+
+    const vrm: VRM = { scene: vrmScene, meta: { specVersion: '0.0' } } as unknown as VRM
+    const gltf: GLTF = { scene: vrmScene, userData: { vrm } } as unknown as GLTF
+
+    const parseSpy = vi.spyOn(GLTFLoader.prototype, 'parseAsync').mockResolvedValue(gltf)
+    const rotateSpy = vi
+      .spyOn(VRMUtils, 'rotateVRM0')
+      .mockImplementation((v: VRM) => {
+        v.scene.rotation.y -= Math.PI
+      })
+
+    const asset = await loadAny(new File([new ArrayBuffer(0)], 'test.vrm'))
+
+    expect(parseSpy).toHaveBeenCalled()
+    expect(rotateSpy).toHaveBeenCalledWith(vrm)
+    expect(asset.vrm).toBe(vrm)
+    expect(Math.abs(asset.vrm.scene.rotation.y)).toBeLessThan(1e-5)
+
+    parseSpy.mockRestore()
+    rotateSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- parse VRM assets via VRMLoaderPlugin
- rotate legacy VRM0 models and expose VRM instances
- update viewport to drive VRM animations each frame
- add placeholder VRM loader test (skipped)

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm test:e2e` *(fails: element not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c1127e6408322ae00d7bd7d2bf02c