### PR TITLE
feat: scaffold digital tailor module

### DIFF
--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -8,7 +8,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Garment import pipeline wired into `useCharacterStore`.
 - Basic pins/simulation state via `useTailorStore`.
 - Stub cloth solver worker and Playwright smoke test for mode toggle.
-- Addressed initial code review: extracted FileDrop kind helpers, simplified file input logic, and centralized error handling.
+- Addressed code review: consolidated kind mapping, routed garment uploads through `onFiles`, replaced global utility styles, and centralized error handling.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -18,6 +18,8 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Added `isLoading` flag and guard in `useCharacterStore` to block concurrent file imports.
 - Clearing tailor pins and simulation state when importing a new garment.
 - Hoisted static kind/label/base maps to module scope for minor render-time savings.
+- Sidebar split into `CharacterModeSidebar` and `TailorModeSidebar` for clearer layout.
+- Tailor store now resets via garment-state subscriber instead of direct calls.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -9,6 +9,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Basic pins/simulation state via `useTailorStore`.
 - Stub cloth solver worker and Playwright smoke test for mode toggle.
 - Addressed code review: consolidated kind mapping, routed garment uploads through `onFiles`, replaced global utility styles, and centralized error handling.
+- Refactored `onFiles` in `useCharacterStore` to remove duplicated logic.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -10,7 +10,8 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Stub cloth solver worker and Playwright smoke test for mode toggle.
 - Addressed code review: consolidated kind mapping, routed garment uploads through `onFiles`, replaced global utility styles, and centralized error handling.
 - Refactored `onFiles` in `useCharacterStore` to remove duplicated logic.
- - Removed redundant type assertions in `useCharacterStore` for clearer inference.
+- Removed redundant type assertions in `useCharacterStore` for clearer inference.
+- Simplified head/body assignment in `onFiles` with a computed key to avoid duplication.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -12,6 +12,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Refactored `onFiles` in `useCharacterStore` to remove duplicated logic.
 - Removed redundant type assertions in `useCharacterStore` for clearer inference.
 - Simplified head/body assignment in `onFiles` with a computed key to avoid duplication.
+- Corrected `pushError` helper typing to accept partial state updates.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -8,6 +8,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Garment import pipeline wired into `useCharacterStore`.
 - Basic pins/simulation state via `useTailorStore`.
 - Stub cloth solver worker and Playwright smoke test for mode toggle.
+- Addressed initial code review: extracted FileDrop kind helpers, simplified file input logic, and centralized error handling.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -15,6 +15,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Corrected `pushError` helper typing to accept partial state updates.
 - Reset variant-related state when loading new head or body bases to avoid stale morphs.
 - Replaced inline spacing divs with semantic CSS classes.
+- Added `isLoading` flag to `useCharacterStore` to block concurrent file imports.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -17,6 +17,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Replaced inline spacing divs with semantic CSS classes.
 - Added `isLoading` flag and guard in `useCharacterStore` to block concurrent file imports.
 - Clearing tailor pins and simulation state when importing a new garment.
+- Hoisted static kind/label/base maps to module scope for minor render-time savings.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -18,6 +18,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Added `isLoading` flag and guard in `useCharacterStore` to block concurrent file imports.
 - Clearing tailor pins and simulation state when importing a new garment.
 - Hoisted static kind/label/base maps to module scope for minor render-time savings.
+- Moved FileDrop hint helper to module scope for minor render-time savings.
 - Sidebar split into `CharacterModeSidebar` and `TailorModeSidebar` for clearer layout.
 - Tailor store now resets via garment-state subscriber instead of direct calls.
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -13,6 +13,8 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Removed redundant type assertions in `useCharacterStore` for clearer inference.
 - Simplified head/body assignment in `onFiles` with a computed key to avoid duplication.
 - Corrected `pushError` helper typing to accept partial state updates.
+- Reset variant-related state when loading new head or body bases to avoid stale morphs.
+- Replaced inline spacing divs with semantic CSS classes.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -1,0 +1,25 @@
+# Digital Tailor Integration Plan
+
+This document tracks progress and remaining work for integrating the **Digital Tailor** garment fitting module into Beya Chara Studio.
+
+## Current Status
+
+- UI shell and store scaffolding for a "Digital Tailor" mode.
+- Garment import pipeline wired into `useCharacterStore`.
+- Basic pins/simulation state via `useTailorStore`.
+- Stub cloth solver worker and Playwright smoke test for mode toggle.
+
+## TODOs
+
+- Interactive pin creation and visual markers in the viewport.
+- Position-Based Dynamics cloth solver with body/self collisions.
+- Garment export after drape with Z-up ×100 transform.
+- Comprehensive unit tests for solver math and pinning.
+- UX polish: numeric transform inputs, pin editing, help tooltips.
+
+## Handoff Notes
+
+- Extend `DigitalTailorPanel` with pin/transform controls.
+- Implement worker messaging between `useTailorStore` and `cloth.worker.ts`.
+- Add e2e scenario covering import → pin → simulate → export.
+- Update documentation once features stabilize.

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -10,6 +10,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Stub cloth solver worker and Playwright smoke test for mode toggle.
 - Addressed code review: consolidated kind mapping, routed garment uploads through `onFiles`, replaced global utility styles, and centralized error handling.
 - Refactored `onFiles` in `useCharacterStore` to remove duplicated logic.
+ - Removed redundant type assertions in `useCharacterStore` for clearer inference.
 
 ## TODOs
 

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -15,7 +15,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Corrected `pushError` helper typing to accept partial state updates.
 - Reset variant-related state when loading new head or body bases to avoid stale morphs.
 - Replaced inline spacing divs with semantic CSS classes.
-- Added `isLoading` flag to `useCharacterStore` to block concurrent file imports.
+- Added `isLoading` flag and guard in `useCharacterStore` to block concurrent file imports.
 - Clearing tailor pins and simulation state when importing a new garment.
 
 ## TODOs

--- a/docs/digital-tailor-plan.md
+++ b/docs/digital-tailor-plan.md
@@ -16,6 +16,7 @@ This document tracks progress and remaining work for integrating the **Digital T
 - Reset variant-related state when loading new head or body bases to avoid stale morphs.
 - Replaced inline spacing divs with semantic CSS classes.
 - Added `isLoading` flag to `useCharacterStore` to block concurrent file imports.
+- Clearing tailor pins and simulation state when importing a new garment.
 
 ## TODOs
 

--- a/e2e/digital-tailor.spec.ts
+++ b/e2e/digital-tailor.spec.ts
@@ -1,0 +1,9 @@
+import { expect, test } from '@playwright/test'
+
+test('digital tailor mode toggles', async ({ page }) => {
+  await page.goto('/')
+  await page.getByText('Enter Digital Tailor').click()
+  await expect(page.getByText('Digital Tailor')).toBeVisible()
+  await page.getByText('Back to Character Mode').click()
+  await expect(page.getByText('Character Morph Creator')).toBeVisible()
+})

--- a/e2e/digital-tailor.spec.ts
+++ b/e2e/digital-tailor.spec.ts
@@ -2,8 +2,10 @@ import { expect, test } from '@playwright/test'
 
 test('digital tailor mode toggles', async ({ page }) => {
   await page.goto('/')
-  await page.getByText('Enter Digital Tailor').click()
-  await expect(page.getByText('Digital Tailor')).toBeVisible()
-  await page.getByText('Back to Character Mode').click()
-  await expect(page.getByText('Character Morph Creator')).toBeVisible()
+  await page.getByRole('button', { name: 'Enter Digital Tailor' }).click()
+  await expect(page.getByRole('heading', { name: 'Digital Tailor' })).toBeVisible()
+  await page.getByRole('button', { name: 'Back to Character Mode' }).click()
+  await expect(
+    page.getByRole('heading', { name: 'Character Morph Creator (GLB-only)' })
+  ).toBeVisible()
 })

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -2,5 +2,7 @@ import { expect, test } from '@playwright/test'
 
 test('app renders', async ({ page }) => {
   await page.goto('/')
-  await expect(page.getByText('Character Morph Creator')).toBeVisible()
+  await expect(
+    page.getByRole('heading', { name: 'Character Morph Creator (GLB-only)' })
+  ).toBeVisible()
 })

--- a/handoff.md
+++ b/handoff.md
@@ -51,7 +51,7 @@
 - **Performance budgets**: synthetic meshes 200k–500k vertices; worker pool sizing UI.
 - **UE import preset doc**: checklist for UE morph import flags, tangent space options, and material merging.
 - **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
-- Code review addressed: FileDrop constants extracted, file accept clarified, shared error helper.
+- Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, and semantic button styles.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -55,6 +55,7 @@
 - Follow-up: removed broad type assertion in `onFiles` by explicitly handling head/body base assignments.
 - Cleanup: dropped redundant `keyof` assertions in `onFiles` to leverage type guard inference.
 - Cleanup: simplified head/body base setting with a computed key to eliminate duplicated branches.
+- Cleanup: narrowed `pushError` helper to `(s:State)=>Partial<State>` for accurate typing.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -51,7 +51,7 @@
 - **Performance budgets**: synthetic meshes 200k–500k vertices; worker pool sizing UI.
 - **UE import preset doc**: checklist for UE morph import flags, tangent space options, and material merging.
 - **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
-- Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, and semantic button styles.
+- Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, semantic button styles, and refactored `onFiles` to avoid duplication.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -56,6 +56,8 @@
 - Cleanup: dropped redundant `keyof` assertions in `onFiles` to leverage type guard inference.
 - Cleanup: simplified head/body base setting with a computed key to eliminate duplicated branches.
 - Cleanup: narrowed `pushError` helper to `(s:State)=>Partial<State>` for accurate typing.
+- Bugfix: reset variants and morph state when loading new head or body bases to avoid stale UI.
+- UI cleanup: swapped inline spacing divs for `.spacer-*` classes.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -59,6 +59,7 @@
 - Bugfix: reset variants and morph state when loading new head or body bases to avoid stale UI.
 - UI cleanup: swapped inline spacing divs for `.spacer-*` classes.
 - UX: added `isLoading` flag to file imports to avoid overlapping uploads.
+- Garment import resets tailor pins and simulation state to prevent stale data.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -54,6 +54,7 @@
 - Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, semantic button styles, and refactored `onFiles` to avoid duplication.
 - Follow-up: removed broad type assertion in `onFiles` by explicitly handling head/body base assignments.
 - Cleanup: dropped redundant `keyof` assertions in `onFiles` to leverage type guard inference.
+- Cleanup: simplified head/body base setting with a computed key to eliminate duplicated branches.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -58,6 +58,7 @@
 - Cleanup: narrowed `pushError` helper to `(s:State)=>Partial<State>` for accurate typing.
 - Bugfix: reset variants and morph state when loading new head or body bases to avoid stale UI.
 - UI cleanup: swapped inline spacing divs for `.spacer-*` classes.
+- UX: added `isLoading` flag to file imports to avoid overlapping uploads.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -58,7 +58,7 @@
 - Cleanup: narrowed `pushError` helper to `(s:State)=>Partial<State>` for accurate typing.
 - Bugfix: reset variants and morph state when loading new head or body bases to avoid stale UI.
 - UI cleanup: swapped inline spacing divs for `.spacer-*` classes.
-- UX: added `isLoading` flag to file imports to avoid overlapping uploads.
+- UX: added `isLoading` flag and guard to file imports to avoid overlapping uploads.
 - Garment import resets tailor pins and simulation state to prevent stale data.
 
 ## Deployment

--- a/handoff.md
+++ b/handoff.md
@@ -53,6 +53,7 @@
 - **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
 - Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, semantic button styles, and refactored `onFiles` to avoid duplication.
 - Follow-up: removed broad type assertion in `onFiles` by explicitly handling head/body base assignments.
+- Cleanup: dropped redundant `keyof` assertions in `onFiles` to leverage type guard inference.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -50,6 +50,7 @@
 - **Save/Load mappings** to JSON; preset library per target skeleton.
 - **Performance budgets**: synthetic meshes 200k–500k vertices; worker pool sizing UI.
 - **UE import preset doc**: checklist for UE morph import flags, tangent space options, and material merging.
+- **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -51,6 +51,7 @@
 - **Performance budgets**: synthetic meshes 200k–500k vertices; worker pool sizing UI.
 - **UE import preset doc**: checklist for UE morph import flags, tangent space options, and material merging.
 - **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
+- Code review addressed: FileDrop constants extracted, file accept clarified, shared error helper.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -52,6 +52,7 @@
 - **UE import preset doc**: checklist for UE morph import flags, tangent space options, and material merging.
 - **Digital Tailor**: garment fitting scaffold added; implement pin UI, cloth solver, and export pipeline.
 - Code review addressed: consolidated FileDrop kind mapping, garment handling moved into `onFiles`, shared error helper, semantic button styles, and refactored `onFiles` to avoid duplication.
+- Follow-up: removed broad type assertion in `onFiles` by explicitly handling head/body base assignments.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -61,6 +61,8 @@
 - UX: added `isLoading` flag and guard to file imports to avoid overlapping uploads.
 - Garment import resets tailor pins and simulation state to prevent stale data.
 - Perf: hoisted static maps (kind/label/base) to module scope to avoid per-render allocation.
+- UI: extracted character and tailor sidebars into dedicated components.
+- State: garment changes trigger tailor resets via store subscription rather than direct calls.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -60,6 +60,7 @@
 - UI cleanup: swapped inline spacing divs for `.spacer-*` classes.
 - UX: added `isLoading` flag and guard to file imports to avoid overlapping uploads.
 - Garment import resets tailor pins and simulation state to prevent stale data.
+- Perf: hoisted static maps (kind/label/base) to module scope to avoid per-render allocation.
 
 ## Deployment
 

--- a/handoff.md
+++ b/handoff.md
@@ -61,6 +61,7 @@
 - UX: added `isLoading` flag and guard to file imports to avoid overlapping uploads.
 - Garment import resets tailor pins and simulation state to prevent stale data.
 - Perf: hoisted static maps (kind/label/base) to module scope to avoid per-render allocation.
+- Perf: moved FileDrop hint helper out of component to avoid per-render recreation.
 - UI: extracted character and tailor sidebars into dedicated components.
 - State: garment changes trigger tailor resets via store subscription rather than direct calls.
 

--- a/index.html
+++ b/index.html
@@ -51,6 +51,9 @@
         border-radius: 999px;
         margin-right: 6px;
       }
+      .ml-2 {
+        margin-left: 8px;
+      }
       input[type='range'] {
         width: 100%;
       }

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         border-radius: 999px;
         margin-right: 6px;
       }
-      .ml-2 {
+      .tailor-export-btn {
         margin-left: 8px;
       }
       input[type='range'] {

--- a/index.html
+++ b/index.html
@@ -54,6 +54,12 @@
       .tailor-export-btn {
         margin-left: 8px;
       }
+      .spacer-sm {
+        height: 8px;
+      }
+      .spacer-md {
+        height: 12px;
+      }
       input[type='range'] {
         width: 100%;
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,12 @@ import { disposeRetargetPool } from './lib/retarget'
 import { useCharacterStore } from './state/useCharacterStore'
 import { useTailorStore } from './state/useTailorStore'
 
+const kindMap = {
+  base: { base: 'base', variant: 'variant' },
+  head: { base: 'headBase', variant: 'headVariant' },
+  body: { base: 'bodyBase', variant: 'bodyVariant' }
+} as const
+
 export default function App() {
   const base = useCharacterStore(s => s.base)
   const variants = useCharacterStore(s => s.variants)
@@ -23,11 +29,6 @@ export default function App() {
   const mode = useTailorStore(s => s.mode)
   const setMode = useTailorStore(s => s.setMode)
 
-  const kindMap = {
-    base: { base: 'base', variant: 'variant' },
-    head: { base: 'headBase', variant: 'headVariant' },
-    body: { base: 'bodyBase', variant: 'bodyVariant' }
-  } as const
   const { base: baseKind, variant: variantKind } = kindMap[activePart]
 
   useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,19 @@ export default function App() {
   const mode = useTailorStore(s => s.mode)
   const setMode = useTailorStore(s => s.setMode)
 
+  const baseKind =
+    activePart === 'head'
+      ? 'headBase'
+      : activePart === 'body'
+      ? 'bodyBase'
+      : 'base'
+  const variantKind =
+    activePart === 'head'
+      ? 'headVariant'
+      : activePart === 'body'
+      ? 'bodyVariant'
+      : 'variant'
+
   useEffect(() => {
     if (typeof window === 'undefined') return
     const cleanup = () => {
@@ -46,9 +59,9 @@ export default function App() {
       <h3>Character Morph Creator (GLB-only)</h3>
       <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
       <PartTabs />
-      <FileDrop kind={activePart==='head' ? 'headBase' : activePart==='body' ? 'bodyBase' : 'base'} />
+      <FileDrop kind={baseKind} />
       <div style={{height:8}} />
-      <FileDrop kind={activePart==='head' ? 'headVariant' : activePart==='body' ? 'bodyVariant' : 'variant'} />
+      <FileDrop kind={variantKind} />
 
       <div style={{height:12}} />
       <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,18 +23,12 @@ export default function App() {
   const mode = useTailorStore(s => s.mode)
   const setMode = useTailorStore(s => s.setMode)
 
-  const baseKind =
-    activePart === 'head'
-      ? 'headBase'
-      : activePart === 'body'
-      ? 'bodyBase'
-      : 'base'
-  const variantKind =
-    activePart === 'head'
-      ? 'headVariant'
-      : activePart === 'body'
-      ? 'bodyVariant'
-      : 'variant'
+  const kindMap = {
+    base: { base: 'base', variant: 'variant' },
+    head: { base: 'headBase', variant: 'headVariant' },
+    body: { base: 'bodyBase', variant: 'bodyVariant' }
+  } as const
+  const { base: baseKind, variant: variantKind } = kindMap[activePart]
 
   useEffect(() => {
     if (typeof window === 'undefined') return

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import { ARKitPanel } from './components/ARKitPanel'
 import { BoneMapEditor } from './components/BoneMapEditor'
 import { ConflictPanel } from './components/ConflictPanel'
+import { DigitalTailorPanel } from './components/DigitalTailorPanel'
 import { ExportPanel } from './components/ExportPanel'
 import { FileDrop } from './components/FileDrop'
 import { MaterialSplitPanel } from './components/MaterialSplitPanel'
@@ -13,11 +14,14 @@ import { Viewport } from './components/Viewport'
 import { disposeMorphPool } from './lib/morphs'
 import { disposeRetargetPool } from './lib/retarget'
 import { useCharacterStore } from './state/useCharacterStore'
+import { useTailorStore } from './state/useTailorStore'
 
 export default function App() {
   const base = useCharacterStore(s => s.base)
   const variants = useCharacterStore(s => s.variants)
   const activePart = useCharacterStore(s => s.activePart)
+  const mode = useTailorStore(s => s.mode)
+  const setMode = useTailorStore(s => s.setMode)
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -32,10 +36,25 @@ export default function App() {
     }
   }, [])
 
+  if (mode === 'tailor') {
+    return (
+      <div className="row">
+        <div className="sidebar">
+          <button className="btn" onClick={() => setMode('character')}>Back to Character Mode</button>
+          <DigitalTailorPanel />
+        </div>
+        <div className="main">
+          <Viewport />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="row">
       <div className="sidebar">
         <h3>Character Morph Creator (GLB-only)</h3>
+        <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
         <PartTabs />
         <FileDrop kind={activePart==='head' ? 'headBase' : activePart==='body' ? 'bodyBase' : 'base'} />
         <div style={{height:8}} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,10 +54,10 @@ export default function App() {
       <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
       <PartTabs />
       <FileDrop kind={baseKind} />
-      <div style={{height:8}} />
+      <div className="spacer-sm" />
       <FileDrop kind={variantKind} />
 
-      <div style={{height:12}} />
+      <div className="spacer-md" />
       <div>
         <div><span className="badge">Active</span>{activePart}</div>
         <div><span className="badge">Base</span>{base?.name ?? 'none'}</div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,14 @@
 import { useEffect } from 'react'
 
-import { ARKitPanel } from './components/ARKitPanel'
-import { BoneMapEditor } from './components/BoneMapEditor'
-import { ConflictPanel } from './components/ConflictPanel'
-import { DigitalTailorPanel } from './components/DigitalTailorPanel'
-import { ExportPanel } from './components/ExportPanel'
-import { FileDrop } from './components/FileDrop'
-import { MaterialSplitPanel } from './components/MaterialSplitPanel'
-import { PartTabs } from './components/PartTabs'
-import { RetargetPanel } from './components/RetargetPanel'
-import { SkeletonBadge } from './components/SkeletonBadge'
+import { CharacterModeSidebar } from './components/CharacterModeSidebar'
+import { TailorModeSidebar } from './components/TailorModeSidebar'
 import { Viewport } from './components/Viewport'
 import { disposeMorphPool } from './lib/morphs'
 import { disposeRetargetPool } from './lib/retarget'
-import { useCharacterStore } from './state/useCharacterStore'
 import { useTailorStore } from './state/useTailorStore'
 
-const kindMap = {
-  base: { base: 'base', variant: 'variant' },
-  head: { base: 'headBase', variant: 'headVariant' },
-  body: { base: 'bodyBase', variant: 'bodyVariant' }
-} as const
-
 export default function App() {
-  const base = useCharacterStore(s => s.base)
-  const variants = useCharacterStore(s => s.variants)
-  const activePart = useCharacterStore(s => s.activePart)
   const mode = useTailorStore(s => s.mode)
-  const setMode = useTailorStore(s => s.setMode)
-
-  const { base: baseKind, variant: variantKind } = kindMap[activePart]
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -44,41 +23,7 @@ export default function App() {
     }
   }, [])
 
-  const sidebar = mode === 'tailor' ? (
-    <>
-      <button className="btn" onClick={() => setMode('character')}>Back to Character Mode</button>
-      <DigitalTailorPanel />
-    </>
-  ) : (
-    <>
-      <h3>Character Morph Creator (GLB-only)</h3>
-      <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
-      <PartTabs />
-      <FileDrop kind={baseKind} />
-      <div className="spacer-sm" />
-      <FileDrop kind={variantKind} />
-
-      <div className="spacer-md" />
-      <div>
-        <div><span className="badge">Active</span>{activePart}</div>
-        <div><span className="badge">Base</span>{base?.name ?? 'none'}</div>
-        <div><span className="badge">Variants</span>{variants.length}</div>
-      </div>
-
-      <SkeletonBadge />
-      <ConflictPanel />
-
-      <hr />
-      <MaterialSplitPanel />
-      <hr />
-      <RetargetPanel />
-      <BoneMapEditor />
-      <hr />
-      <ExportPanel />
-      <hr />
-      <ARKitPanel />
-    </>
-  )
+  const sidebar = mode === 'tailor' ? <TailorModeSidebar /> : <CharacterModeSidebar />
 
   return (
     <div className="row">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,50 +36,45 @@ export default function App() {
     }
   }, [])
 
-  if (mode === 'tailor') {
-    return (
-      <div className="row">
-        <div className="sidebar">
-          <button className="btn" onClick={() => setMode('character')}>Back to Character Mode</button>
-          <DigitalTailorPanel />
-        </div>
-        <div className="main">
-          <Viewport />
-        </div>
+  const sidebar = mode === 'tailor' ? (
+    <>
+      <button className="btn" onClick={() => setMode('character')}>Back to Character Mode</button>
+      <DigitalTailorPanel />
+    </>
+  ) : (
+    <>
+      <h3>Character Morph Creator (GLB-only)</h3>
+      <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
+      <PartTabs />
+      <FileDrop kind={activePart==='head' ? 'headBase' : activePart==='body' ? 'bodyBase' : 'base'} />
+      <div style={{height:8}} />
+      <FileDrop kind={activePart==='head' ? 'headVariant' : activePart==='body' ? 'bodyVariant' : 'variant'} />
+
+      <div style={{height:12}} />
+      <div>
+        <div><span className="badge">Active</span>{activePart}</div>
+        <div><span className="badge">Base</span>{base?.name ?? 'none'}</div>
+        <div><span className="badge">Variants</span>{variants.length}</div>
       </div>
-    )
-  }
+
+      <SkeletonBadge />
+      <ConflictPanel />
+
+      <hr />
+      <MaterialSplitPanel />
+      <hr />
+      <RetargetPanel />
+      <BoneMapEditor />
+      <hr />
+      <ExportPanel />
+      <hr />
+      <ARKitPanel />
+    </>
+  )
 
   return (
     <div className="row">
-      <div className="sidebar">
-        <h3>Character Morph Creator (GLB-only)</h3>
-        <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
-        <PartTabs />
-        <FileDrop kind={activePart==='head' ? 'headBase' : activePart==='body' ? 'bodyBase' : 'base'} />
-        <div style={{height:8}} />
-        <FileDrop kind={activePart==='head' ? 'headVariant' : activePart==='body' ? 'bodyVariant' : 'variant'} />
-
-        <div style={{height:12}} />
-        <div>
-          <div><span className="badge">Active</span>{activePart}</div>
-          <div><span className="badge">Base</span>{base?.name ?? 'none'}</div>
-          <div><span className="badge">Variants</span>{variants.length}</div>
-        </div>
-
-        <SkeletonBadge />
-        <ConflictPanel />
-
-        <hr />
-        <MaterialSplitPanel />
-        <hr />
-        <RetargetPanel />
-        <BoneMapEditor />
-        <hr />
-        <ExportPanel />
-        <hr />
-        <ARKitPanel />
-      </div>
+      <div className="sidebar">{sidebar}</div>
       <div className="main">
         <Viewport />
       </div>

--- a/src/components/CharacterModeSidebar.tsx
+++ b/src/components/CharacterModeSidebar.tsx
@@ -1,0 +1,51 @@
+import { kindMap } from '../lib/kindMap'
+import { useCharacterStore } from '../state/useCharacterStore'
+import { useTailorStore } from '../state/useTailorStore'
+import { ARKitPanel } from './ARKitPanel'
+import { BoneMapEditor } from './BoneMapEditor'
+import { ConflictPanel } from './ConflictPanel'
+import { ExportPanel } from './ExportPanel'
+import { FileDrop } from './FileDrop'
+import { MaterialSplitPanel } from './MaterialSplitPanel'
+import { PartTabs } from './PartTabs'
+import { RetargetPanel } from './RetargetPanel'
+import { SkeletonBadge } from './SkeletonBadge'
+
+export function CharacterModeSidebar() {
+  const base = useCharacterStore(s => s.base)
+  const variants = useCharacterStore(s => s.variants)
+  const activePart = useCharacterStore(s => s.activePart)
+  const { base: baseKind, variant: variantKind } = kindMap[activePart]
+  const setMode = useTailorStore(s => s.setMode)
+
+  return (
+    <>
+      <h3>Character Morph Creator (GLB-only)</h3>
+      <button className="btn" onClick={() => setMode('tailor')}>Enter Digital Tailor</button>
+      <PartTabs />
+      <FileDrop kind={baseKind} />
+      <div className="spacer-sm" />
+      <FileDrop kind={variantKind} />
+
+      <div className="spacer-md" />
+      <div>
+        <div><span className="badge">Active</span>{activePart}</div>
+        <div><span className="badge">Base</span>{base?.name ?? 'none'}</div>
+        <div><span className="badge">Variants</span>{variants.length}</div>
+      </div>
+
+      <SkeletonBadge />
+      <ConflictPanel />
+
+      <hr />
+      <MaterialSplitPanel />
+      <hr />
+      <RetargetPanel />
+      <BoneMapEditor />
+      <hr />
+      <ExportPanel />
+      <hr />
+      <ARKitPanel />
+    </>
+  )
+}

--- a/src/components/DigitalTailorPanel.tsx
+++ b/src/components/DigitalTailorPanel.tsx
@@ -18,7 +18,7 @@ export function DigitalTailorPanel() {
       <button className="btn" disabled={!garment} onClick={() => setSimulating(!isSim)}>
         {isSim ? 'Stop Simulation' : 'Simulate Draping'}
       </button>
-      <button className="btn ml-2" disabled={!garment}>Export Garment</button>
+      <button className="btn tailor-export-btn" disabled={!garment}>Export Garment</button>
     </div>
   )
 }

--- a/src/components/DigitalTailorPanel.tsx
+++ b/src/components/DigitalTailorPanel.tsx
@@ -1,0 +1,24 @@
+import { useCharacterStore } from '../state/useCharacterStore'
+import { useTailorStore } from '../state/useTailorStore'
+import { FileDrop } from './FileDrop'
+
+export function DigitalTailorPanel() {
+  const garment = useCharacterStore(s => s.garment)
+  const isSim = useTailorStore(s => s.isSimulating)
+  const setSimulating = useTailorStore(s => s.setSimulating)
+
+  return (
+    <div>
+      <h3>Digital Tailor</h3>
+      {!garment ? (
+        <FileDrop kind="garment" />
+      ) : (
+        <div><span className="badge">Garment</span>{garment.name ?? 'loaded'}</div>
+      )}
+      <button className="btn" disabled={!garment} onClick={() => setSimulating(!isSim)}>
+        {isSim ? 'Stop Simulation' : 'Simulate Draping'}
+      </button>
+      <button className="btn" disabled={!garment} style={{marginLeft:8}}>Export Garment</button>
+    </div>
+  )
+}

--- a/src/components/DigitalTailorPanel.tsx
+++ b/src/components/DigitalTailorPanel.tsx
@@ -18,7 +18,7 @@ export function DigitalTailorPanel() {
       <button className="btn" disabled={!garment} onClick={() => setSimulating(!isSim)}>
         {isSim ? 'Stop Simulation' : 'Simulate Draping'}
       </button>
-      <button className="btn" disabled={!garment} style={{marginLeft:8}}>Export Garment</button>
+      <button className="btn ml-2" disabled={!garment}>Export Garment</button>
     </div>
   )
 }

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -16,14 +16,9 @@ export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVarian
   } as const
   const label = labelMap[kind]
   const multi = kind==='variant' || kind==='headVariant' || kind==='bodyVariant'
-  const hintMap: Record<typeof kind, string> = {
-    base: 'Base first.',
-    variant: 'Variants must match topology & skin.',
-    headBase: 'Base first.',
-    headVariant: 'Variants must match topology & skin.',
-    bodyBase: 'Base first.',
-    bodyVariant: 'Variants must match topology & skin.',
-    garment: 'Garment must be a skinned mesh.'
+  const getHintText = (k: typeof kind) => {
+    if (k === 'garment') return 'Garment must be a skinned mesh.'
+    return k.endsWith('Base') ? 'Base first.' : 'Variants must match topology & skin.'
   }
   const handle = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
@@ -35,7 +30,7 @@ export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVarian
     <div className="drop">
       <div>{label}</div>
       <input type="file" accept=".fbx,.glb,.gltf,.vrm" multiple={multi} onChange={handle} />
-      <small>{hintMap[kind]}</small>
+      <small>{getHintText(kind)}</small>
     </div>
   )
 }

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -15,7 +15,7 @@ export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVarian
     garment: 'Upload Garment GLB'
   } as const
   const label = labelMap[kind]
-  const multi = kind==='variant' || kind==='headVariant' || kind==='bodyVariant'
+  const multi = kind.endsWith('Variant')
   const getHintText = (k: typeof kind) => {
     if (k === 'garment') return 'Garment must be a skinned mesh.'
     return k.endsWith('Base') ? 'Base first.' : 'Variants must match topology & skin.'
@@ -29,7 +29,7 @@ export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVarian
   return (
     <div className="drop">
       <div>{label}</div>
-      <input type="file" accept=".fbx,.glb,.gltf,.vrm" multiple={multi} onChange={handle} />
+      <input type="file" accept={kind === 'garment' ? '.glb' : '.fbx,.glb,.gltf,.vrm'} multiple={multi} onChange={handle} />
       <small>{getHintText(kind)}</small>
     </div>
   )

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -12,14 +12,15 @@ const labelMap = {
   garment: 'Upload Garment GLB'
 } as const
 
+const getHintText = (k: Part) => {
+  if (k === 'garment') return 'Garment must be a skinned mesh.'
+  return k.endsWith('Base') ? 'Base first.' : 'Variants must match topology & skin.'
+}
+
 export function FileDrop({ kind }: { kind: Part }) {
   const onFiles = useCharacterStore(s => s.onFiles)
   const label = labelMap[kind]
   const multi = kind.endsWith('Variant')
-  const getHintText = (k: typeof kind) => {
-    if (k === 'garment') return 'Garment must be a skinned mesh.'
-    return k.endsWith('Base') ? 'Base first.' : 'Variants must match topology & skin.'
-  }
   const handle = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
     onFiles(kind, files)

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -1,10 +1,9 @@
 import { type ChangeEvent, useCallback } from 'react'
 
-import { useCharacterStore } from '../state/useCharacterStore'
+import { useCharacterStore, type Part } from '../state/useCharacterStore'
 
-export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVariant'|'bodyBase'|'bodyVariant'|'garment' }) {
+export function FileDrop({ kind }: { kind: Part }) {
   const onFiles = useCharacterStore(s => s.onFiles)
-  const onGarmentFiles = useCharacterStore(s => s.onGarmentFiles)
   const labelMap = {
     base: 'Upload Base FBX',
     variant: 'Upload Variant FBX',
@@ -22,10 +21,9 @@ export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVarian
   }
   const handle = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
-    if (kind === 'garment') onGarmentFiles(files)
-    else onFiles(kind, files)
+    onFiles(kind, files)
     e.currentTarget.value = ''
-  }, [kind, onFiles, onGarmentFiles])
+  }, [kind, onFiles])
   return (
     <div className="drop">
       <div>{label}</div>

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -1,18 +1,19 @@
 import { type ChangeEvent, useCallback } from 'react'
 
-import { useCharacterStore, type Part } from '../state/useCharacterStore'
+import { type Part, useCharacterStore } from '../state/useCharacterStore'
+
+const labelMap = {
+  base: 'Upload Base FBX',
+  variant: 'Upload Variant FBX',
+  headBase: 'Upload Head Base FBX',
+  headVariant: 'Upload Head Variant FBX',
+  bodyBase: 'Upload Body Base FBX',
+  bodyVariant: 'Upload Body Variant FBX',
+  garment: 'Upload Garment GLB'
+} as const
 
 export function FileDrop({ kind }: { kind: Part }) {
   const onFiles = useCharacterStore(s => s.onFiles)
-  const labelMap = {
-    base: 'Upload Base FBX',
-    variant: 'Upload Variant FBX',
-    headBase: 'Upload Head Base FBX',
-    headVariant: 'Upload Head Variant FBX',
-    bodyBase: 'Upload Body Base FBX',
-    bodyVariant: 'Upload Body Variant FBX',
-    garment: 'Upload Garment GLB'
-  } as const
   const label = labelMap[kind]
   const multi = kind.endsWith('Variant')
   const getHintText = (k: typeof kind) => {

--- a/src/components/FileDrop.tsx
+++ b/src/components/FileDrop.tsx
@@ -2,28 +2,40 @@ import { type ChangeEvent, useCallback } from 'react'
 
 import { useCharacterStore } from '../state/useCharacterStore'
 
-export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVariant'|'bodyBase'|'bodyVariant' }) {
+export function FileDrop({ kind }:{ kind:'base'|'variant'|'headBase'|'headVariant'|'bodyBase'|'bodyVariant'|'garment' }) {
   const onFiles = useCharacterStore(s => s.onFiles)
+  const onGarmentFiles = useCharacterStore(s => s.onGarmentFiles)
   const labelMap = {
     base: 'Upload Base FBX',
     variant: 'Upload Variant FBX',
     headBase: 'Upload Head Base FBX',
     headVariant: 'Upload Head Variant FBX',
     bodyBase: 'Upload Body Base FBX',
-    bodyVariant: 'Upload Body Variant FBX'
+    bodyVariant: 'Upload Body Variant FBX',
+    garment: 'Upload Garment GLB'
   } as const
   const label = labelMap[kind]
   const multi = kind==='variant' || kind==='headVariant' || kind==='bodyVariant'
+  const hintMap: Record<typeof kind, string> = {
+    base: 'Base first.',
+    variant: 'Variants must match topology & skin.',
+    headBase: 'Base first.',
+    headVariant: 'Variants must match topology & skin.',
+    bodyBase: 'Base first.',
+    bodyVariant: 'Variants must match topology & skin.',
+    garment: 'Garment must be a skinned mesh.'
+  }
   const handle = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     const files = Array.from(e.target.files ?? [])
-    onFiles(kind, files)
+    if (kind === 'garment') onGarmentFiles(files)
+    else onFiles(kind, files)
     e.currentTarget.value = ''
-  }, [kind, onFiles])
+  }, [kind, onFiles, onGarmentFiles])
   return (
     <div className="drop">
       <div>{label}</div>
       <input type="file" accept=".fbx,.glb,.gltf,.vrm" multiple={multi} onChange={handle} />
-      <small>{kind.endsWith('Base') ? 'Base first.' : 'Variants must match topology & skin.'}</small>
+      <small>{hintMap[kind]}</small>
     </div>
   )
 }

--- a/src/components/TailorModeSidebar.tsx
+++ b/src/components/TailorModeSidebar.tsx
@@ -1,0 +1,12 @@
+import { useTailorStore } from '../state/useTailorStore'
+import { DigitalTailorPanel } from './DigitalTailorPanel'
+
+export function TailorModeSidebar() {
+  const setMode = useTailorStore(s => s.setMode)
+  return (
+    <>
+      <button className="btn" onClick={() => setMode('character')}>Back to Character Mode</button>
+      <DigitalTailorPanel />
+    </>
+  )
+}

--- a/src/lib/kindMap.ts
+++ b/src/lib/kindMap.ts
@@ -1,0 +1,7 @@
+export const kindMap = {
+  base: { base: 'base', variant: 'variant' },
+  head: { base: 'headBase', variant: 'headVariant' },
+  body: { base: 'bodyBase', variant: 'bodyVariant' }
+} as const
+
+export type KindMap = typeof kindMap

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,8 @@
 import { createRoot } from 'react-dom/client'
 
 import App from './App'
+import { initGarmentSubscriber } from './state/subscriptions'
+
+initGarmentSubscriber()
 
 createRoot(document.getElementById('root')!).render(<App />)

--- a/src/state/subscriptions.ts
+++ b/src/state/subscriptions.ts
@@ -1,0 +1,11 @@
+import { useCharacterStore } from './useCharacterStore'
+import { useTailorStore } from './useTailorStore'
+
+export function initGarmentSubscriber() {
+  return useCharacterStore.subscribe((state, prev) => {
+    if (state.garment && state.garment !== prev.garment) {
+      useTailorStore.getState().clearPins()
+      useTailorStore.getState().setSimulating(false)
+    }
+  })
+}

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -36,7 +36,10 @@ type State = {
   clearErrors: ()=>void
 }
 
-const pushError = (set:(fn:(s:State)=>State)=>void, msg:string) => {
+const pushError = (
+  set: (fn: (s: State) => Partial<State>) => void,
+  msg: string
+) => {
   set(s => ({ errors: [...s.errors, msg] }))
 }
 

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -15,6 +15,7 @@ type State = {
   head: AnyAsset | null
   body: AnyAsset | null
   garment: AnyAsset | null
+  isLoading: boolean
   activePart: ActivePart
   errors: string[]
   variants: string[]
@@ -48,6 +49,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   head: null,
   body: null,
   garment: null,
+  isLoading: false,
   activePart: 'base',
   errors: [],
   variants: [],
@@ -77,21 +79,22 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   }),
   onFiles: async (kind, files) => {
     if (!files.length) return
+    set({ isLoading: true, errors: [] })
     const baseMap = { base: 'base', headBase: 'head', bodyBase: 'body' } as const
     const variantMap = { variant: 'base', headVariant: 'head', bodyVariant: 'body' } as const
     try {
       if (kind === 'garment') {
         const asset = await loadAny(files[0])
-        set({ garment: asset, errors: [] })
+        set({ garment: asset })
         return
       }
       if (kind in baseMap) {
         const asset = await loadAny(files[0])
         const key = baseMap[kind]
         if (key === 'base') {
-          set({ base: asset, morphKeys: [], morphWeights: {}, variants: [], errors: [] })
+          set({ base: asset, morphKeys: [], morphWeights: {}, variants: [] })
         } else {
-          set({ [key]: asset, errors: [], variants: [], morphKeys: [], morphWeights: {} })
+          set({ [key]: asset, variants: [], morphKeys: [], morphWeights: {} })
         }
         return
       }
@@ -117,6 +120,8 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       pushError(set, msg)
+    } finally {
+      set({ isLoading: false })
     }
   }
   }), {

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -5,7 +5,6 @@ import { persist } from 'zustand/middleware'
 import { loadAny } from '../lib/importers'
 import { addVariantAsMorph } from '../lib/morphs'
 import type { AnyAsset } from '../types'
-import { useTailorStore } from './useTailorStore'
 
 export type Part = 'base'|'variant'|'headBase'|'headVariant'|'bodyBase'|'bodyVariant'|'garment'
 export type ActivePart = 'base'|'head'|'body'
@@ -89,8 +88,6 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
       if (kind === 'garment') {
         const asset = await loadAny(files[0])
         set({ garment: asset })
-        useTailorStore.getState().clearPins()
-        useTailorStore.getState().setSimulating(false)
         return
       }
       if (kind in baseMap) {

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -138,6 +138,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
     }
   },
   onGarmentFiles: async (files) => {
+    if (!files.length) return
     const pushErr = (msg:string) => set(s => ({ errors: [...s.errors, msg] }))
     try {
       const asset = await loadAny(files[0])

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -45,6 +45,9 @@ const pushError = (
   set(s => ({ errors: [...s.errors, msg] }))
 }
 
+const baseMap = { base: 'base', headBase: 'head', bodyBase: 'body' } as const
+const variantMap = { variant: 'base', headVariant: 'head', bodyVariant: 'body' } as const
+
 export const useCharacterStore = create<State>()(persist((set,get)=> ({
   base: null,
   head: null,
@@ -82,8 +85,6 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
     if (get().isLoading) return
     if (!files.length) return
     set({ isLoading: true, errors: [] })
-    const baseMap = { base: 'base', headBase: 'head', bodyBase: 'body' } as const
-    const variantMap = { variant: 'base', headVariant: 'head', bodyVariant: 'body' } as const
     try {
       if (kind === 'garment') {
         const asset = await loadAny(files[0])

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -84,7 +84,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
       }
       if (kind in baseMap) {
         const asset = await loadAny(files[0])
-        const key = baseMap[kind as keyof typeof baseMap]
+        const key = baseMap[kind]
         if (key === 'base') {
           set({ base: asset, morphKeys: [], morphWeights: {}, variants: [], errors: [] })
         } else if (key === 'head') {
@@ -95,7 +95,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
         return
       }
       if (kind in variantMap) {
-        const parentKey = variantMap[kind as keyof typeof variantMap]
+        const parentKey = variantMap[kind]
         const parent = get()[parentKey]
         if (!parent) {
           const name = parentKey === 'base' ? 'base' : `${parentKey} base`

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -87,10 +87,8 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
         const key = baseMap[kind]
         if (key === 'base') {
           set({ base: asset, morphKeys: [], morphWeights: {}, variants: [], errors: [] })
-        } else if (key === 'head') {
-          set({ head: asset, errors: [] })
         } else {
-          set({ body: asset, errors: [] })
+          set({ [key]: asset, errors: [] })
         }
         return
       }

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -87,8 +87,10 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
         const key = baseMap[kind as keyof typeof baseMap]
         if (key === 'base') {
           set({ base: asset, morphKeys: [], morphWeights: {}, variants: [], errors: [] })
+        } else if (key === 'head') {
+          set({ head: asset, errors: [] })
         } else {
-          set({ [key]: asset, errors: [] } as unknown as Partial<State>)
+          set({ body: asset, errors: [] })
         }
         return
       }

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -5,6 +5,7 @@ import { persist } from 'zustand/middleware'
 import { loadAny } from '../lib/importers'
 import { addVariantAsMorph } from '../lib/morphs'
 import type { AnyAsset } from '../types'
+import { useTailorStore } from './useTailorStore'
 
 export type Part = 'base'|'variant'|'headBase'|'headVariant'|'bodyBase'|'bodyVariant'|'garment'
 export type ActivePart = 'base'|'head'|'body'
@@ -86,6 +87,8 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
       if (kind === 'garment') {
         const asset = await loadAny(files[0])
         set({ garment: asset })
+        useTailorStore.getState().clearPins()
+        useTailorStore.getState().setSimulating(false)
         return
       }
       if (kind in baseMap) {

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -14,6 +14,7 @@ type State = {
   base: AnyAsset | null
   head: AnyAsset | null
   body: AnyAsset | null
+  garment: AnyAsset | null
   activePart: ActivePart
   errors: string[]
   variants: string[]
@@ -25,6 +26,7 @@ type State = {
   selSrcBone?: string
   selDstBone?: string
   onFiles: (kind:Part, files: File[]) => Promise<void>
+  onGarmentFiles: (files: File[]) => Promise<void>
   setMorphWeight: (key:string, v:number)=>void
   setActivePart: (p:ActivePart)=>void
   setMaterialAssign: (key:string, v:'head'|'body'|'none')=>void
@@ -39,6 +41,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
   base: null,
   head: null,
   body: null,
+  garment: null,
   activePart: 'base',
   errors: [],
   variants: [],
@@ -129,6 +132,16 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
         }
         return
       }
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e)
+      pushErr(msg)
+    }
+  },
+  onGarmentFiles: async (files) => {
+    const pushErr = (msg:string) => set(s => ({ errors: [...s.errors, msg] }))
+    try {
+      const asset = await loadAny(files[0])
+      set({ garment: asset, errors: [] })
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       pushErr(msg)

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -79,6 +79,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
     return { morphKeys: keys, morphWeights: weights }
   }),
   onFiles: async (kind, files) => {
+    if (get().isLoading) return
     if (!files.length) return
     set({ isLoading: true, errors: [] })
     const baseMap = { base: 'base', headBase: 'head', bodyBase: 'body' } as const

--- a/src/state/useCharacterStore.ts
+++ b/src/state/useCharacterStore.ts
@@ -91,7 +91,7 @@ export const useCharacterStore = create<State>()(persist((set,get)=> ({
         if (key === 'base') {
           set({ base: asset, morphKeys: [], morphWeights: {}, variants: [], errors: [] })
         } else {
-          set({ [key]: asset, errors: [] })
+          set({ [key]: asset, errors: [], variants: [], morphKeys: [], morphWeights: {} })
         }
         return
       }

--- a/src/state/useTailorStore.ts
+++ b/src/state/useTailorStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+export type TailorPin = { vertex: number, type: 'fixed', target: [number, number, number] }
+
+type State = {
+  mode: 'character' | 'tailor'
+  pins: TailorPin[]
+  isSimulating: boolean
+  setMode: (m: 'character' | 'tailor') => void
+  addPin: (p: TailorPin) => void
+  clearPins: () => void
+  setSimulating: (v: boolean) => void
+}
+
+export const useTailorStore = create<State>(set => ({
+  mode: 'character',
+  pins: [],
+  isSimulating: false,
+  setMode: m => set({ mode: m }),
+  addPin: p => set(s => ({ pins: [...s.pins, p] })),
+  clearPins: () => set({ pins: [] }),
+  setSimulating: v => set({ isSimulating: v })
+}))

--- a/src/workers/cloth.worker.ts
+++ b/src/workers/cloth.worker.ts
@@ -1,0 +1,14 @@
+import * as Comlink from 'comlink'
+
+type SimInput = {
+  positions: Float32Array
+}
+
+const api = {
+  simulate({ positions }: SimInput) {
+    // stub: no-op simulation
+    return positions
+  },
+}
+
+Comlink.expose(api)

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { useCharacterStore } from '../src/state/useCharacterStore'
+import type { AnyAsset } from '../src/types'
+
+vi.mock('../src/lib/importers', () => ({
+  loadAny: vi.fn(async () => ({ name: 'garment', geometry: {} } as AnyAsset))
+}))
+
+describe('garment import', () => {
+  it('stores garment asset', async () => {
+    const file = new File([''], 'garment.glb')
+    await useCharacterStore.getState().onGarmentFiles([file])
+    expect(useCharacterStore.getState().garment?.name).toBe('garment')
+  })
+})

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -9,8 +9,11 @@ vi.mock('../src/lib/importers', () => ({
 
 describe('garment import', () => {
   it('stores garment asset', async () => {
+    useCharacterStore.setState({ garment: null, errors: [] })
     const file = new File([''], 'garment.glb')
     await useCharacterStore.getState().onGarmentFiles([file])
-    expect(useCharacterStore.getState().garment?.name).toBe('garment')
+    const state = useCharacterStore.getState()
+    expect(state.garment?.name).toBe('garment')
+    expect(state.errors).toHaveLength(0)
   })
 })

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
 import { useCharacterStore } from '../src/state/useCharacterStore'
+import { useTailorStore } from '../src/state/useTailorStore'
 import type { AnyAsset } from '../src/types'
 
 let resolveLoad: (asset: AnyAsset) => void
@@ -11,6 +12,7 @@ vi.mock('../src/lib/importers', () => ({
 describe('garment import', () => {
   it('stores garment asset', async () => {
     useCharacterStore.setState({ garment: null, errors: [], isLoading: false })
+    useTailorStore.setState({ pins: [{ vertex: 1, type: 'fixed', target: [0,0,0] }], isSimulating: true })
     const file = new File([''], 'garment.glb')
     const p = useCharacterStore.getState().onFiles('garment', [file])
     expect(useCharacterStore.getState().isLoading).toBe(true)
@@ -20,5 +22,8 @@ describe('garment import', () => {
     expect(state.isLoading).toBe(false)
     expect(state.garment?.name).toBe('garment')
     expect(state.errors).toHaveLength(0)
+    const tState = useTailorStore.getState()
+    expect(tState.pins).toHaveLength(0)
+    expect(tState.isSimulating).toBe(false)
   })
 })

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -8,6 +8,7 @@ let resolveLoad: (asset: AnyAsset) => void
 vi.mock('../src/lib/importers', () => ({
   loadAny: vi.fn(() => new Promise<AnyAsset>(r => { resolveLoad = r }))
 }))
+import { loadAny } from '../src/lib/importers'
 
 describe('garment import', () => {
   it('stores garment asset', async () => {
@@ -25,5 +26,13 @@ describe('garment import', () => {
     const tState = useTailorStore.getState()
     expect(tState.pins).toHaveLength(0)
     expect(tState.isSimulating).toBe(false)
+  })
+
+  it('ignores uploads while loading', async () => {
+    useCharacterStore.setState({ isLoading: true, garment: null, errors: [] })
+    vi.clearAllMocks()
+    await useCharacterStore.getState().onFiles('garment', [new File([''], 'g.glb')])
+    expect(loadAny).not.toHaveBeenCalled()
+    expect(useCharacterStore.getState().garment).toBeNull()
   })
 })

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 
+import { initGarmentSubscriber } from '../src/state/subscriptions'
 import { useCharacterStore } from '../src/state/useCharacterStore'
 import { useTailorStore } from '../src/state/useTailorStore'
 import type { AnyAsset } from '../src/types'
@@ -11,6 +12,9 @@ vi.mock('../src/lib/importers', () => ({
 import { loadAny } from '../src/lib/importers'
 
 describe('garment import', () => {
+  beforeAll(() => {
+    initGarmentSubscriber()
+  })
   it('stores garment asset', async () => {
     useCharacterStore.setState({ garment: null, errors: [], isLoading: false })
     useTailorStore.setState({ pins: [{ vertex: 1, type: 'fixed', target: [0,0,0] }], isSimulating: true })

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -11,7 +11,7 @@ describe('garment import', () => {
   it('stores garment asset', async () => {
     useCharacterStore.setState({ garment: null, errors: [] })
     const file = new File([''], 'garment.glb')
-    await useCharacterStore.getState().onGarmentFiles([file])
+    await useCharacterStore.getState().onFiles('garment', [file])
     const state = useCharacterStore.getState()
     expect(state.garment?.name).toBe('garment')
     expect(state.errors).toHaveLength(0)

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -3,16 +3,21 @@ import { describe, expect, it, vi } from 'vitest'
 import { useCharacterStore } from '../src/state/useCharacterStore'
 import type { AnyAsset } from '../src/types'
 
+let resolveLoad: (asset: AnyAsset) => void
 vi.mock('../src/lib/importers', () => ({
-  loadAny: vi.fn(async () => ({ name: 'garment', geometry: {} } as AnyAsset))
+  loadAny: vi.fn(() => new Promise<AnyAsset>(r => { resolveLoad = r }))
 }))
 
 describe('garment import', () => {
   it('stores garment asset', async () => {
-    useCharacterStore.setState({ garment: null, errors: [] })
+    useCharacterStore.setState({ garment: null, errors: [], isLoading: false })
     const file = new File([''], 'garment.glb')
-    await useCharacterStore.getState().onFiles('garment', [file])
+    const p = useCharacterStore.getState().onFiles('garment', [file])
+    expect(useCharacterStore.getState().isLoading).toBe(true)
+    resolveLoad({ name: 'garment', geometry: {} } as AnyAsset)
+    await p
     const state = useCharacterStore.getState()
+    expect(state.isLoading).toBe(false)
     expect(state.garment?.name).toBe('garment')
     expect(state.errors).toHaveLength(0)
   })

--- a/tests/tailor-store.spec.ts
+++ b/tests/tailor-store.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { useTailorStore } from '../src/state/useTailorStore'
+
+describe('tailor store', () => {
+  it('adds pins immutably', () => {
+    useTailorStore.setState({ pins: [] })
+    useTailorStore.getState().addPin({ vertex: 1, type: 'fixed', target: [0, 0, 0] })
+    expect(useTailorStore.getState().pins).toHaveLength(1)
+  })
+
+  it('toggles mode', () => {
+    useTailorStore.setState({ mode: 'character' })
+    useTailorStore.getState().setMode('tailor')
+    expect(useTailorStore.getState().mode).toBe('tailor')
+  })
+})


### PR DESCRIPTION
## Summary
- scaffold Digital Tailor mode with panel, store and cloth worker stub
- allow garment imports via useCharacterStore and FileDrop
- add basic unit tests and Playwright toggle scenario

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm test:e2e` *(fails: element not found for smoke/digital tailor tests)*

------
https://chatgpt.com/codex/tasks/task_e_689c30c5fa7c832290edfdcc6cde3f94