### PR TITLE
Reset tailor state when garment changes

### DIFF
--- a/src/state/subscriptions.ts
+++ b/src/state/subscriptions.ts
@@ -4,8 +4,9 @@ import { useTailorStore } from './useTailorStore'
 export function initGarmentSubscriber() {
   return useCharacterStore.subscribe((state, prev) => {
     if (state.garment !== prev.garment) {
-      useTailorStore.getState().clearPins()
-      useTailorStore.getState().setSimulating(false)
+      const tailorState = useTailorStore.getState()
+      tailorState.clearPins()
+      tailorState.setSimulating(false)
     }
   })
 }

--- a/src/state/subscriptions.ts
+++ b/src/state/subscriptions.ts
@@ -3,7 +3,7 @@ import { useTailorStore } from './useTailorStore'
 
 export function initGarmentSubscriber() {
   return useCharacterStore.subscribe((state, prev) => {
-    if (state.garment && state.garment !== prev.garment) {
+    if (state.garment !== prev.garment) {
       useTailorStore.getState().clearPins()
       useTailorStore.getState().setSimulating(false)
     }

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -27,18 +27,14 @@ describe('garment import', () => {
     expect(state.isLoading).toBe(false)
     expect(state.garment?.name).toBe('garment')
     expect(state.errors).toHaveLength(0)
-    const tState = useTailorStore.getState()
-    expect(tState.pins).toHaveLength(0)
-    expect(tState.isSimulating).toBe(false)
+    expect(useTailorStore.getState()).toMatchObject({ pins: [], isSimulating: false })
   })
 
   it('clears tailor state when garment removed', () => {
     useCharacterStore.setState({ garment: { name: 'g', geometry: {} } as AnyAsset })
     useTailorStore.setState({ pins: [{ vertex: 1, type: 'fixed', target: [0,0,0] }], isSimulating: true })
     useCharacterStore.setState({ garment: null })
-    const tState = useTailorStore.getState()
-    expect(tState.pins).toHaveLength(0)
-    expect(tState.isSimulating).toBe(false)
+    expect(useTailorStore.getState()).toMatchObject({ pins: [], isSimulating: false })
   })
 
   it('ignores uploads while loading', async () => {

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -4,6 +4,7 @@ import { initGarmentSubscriber } from '../src/state/subscriptions'
 import { useCharacterStore } from '../src/state/useCharacterStore'
 import { useTailorStore } from '../src/state/useTailorStore'
 import type { AnyAsset } from '../src/types'
+import { mockAsset } from './helpers'
 
 let resolveLoad: (asset: AnyAsset) => void
 vi.mock('../src/lib/importers', () => ({
@@ -21,7 +22,7 @@ describe('garment import', () => {
     const file = new File([''], 'garment.glb')
     const p = useCharacterStore.getState().onFiles('garment', [file])
     expect(useCharacterStore.getState().isLoading).toBe(true)
-    resolveLoad({ name: 'garment', geometry: {} } as AnyAsset)
+    resolveLoad(mockAsset({ name: 'garment' }))
     await p
     const state = useCharacterStore.getState()
     expect(state.isLoading).toBe(false)
@@ -31,7 +32,7 @@ describe('garment import', () => {
   })
 
   it('clears tailor state when garment removed', () => {
-    useCharacterStore.setState({ garment: { name: 'g', geometry: {} } as AnyAsset })
+    useCharacterStore.setState({ garment: mockAsset({ name: 'g' }) })
     useTailorStore.setState({ pins: [{ vertex: 1, type: 'fixed', target: [0,0,0] }], isSimulating: true })
     useCharacterStore.setState({ garment: null })
     expect(useTailorStore.getState()).toMatchObject({ pins: [], isSimulating: false })

--- a/tests/garment.spec.ts
+++ b/tests/garment.spec.ts
@@ -32,6 +32,15 @@ describe('garment import', () => {
     expect(tState.isSimulating).toBe(false)
   })
 
+  it('clears tailor state when garment removed', () => {
+    useCharacterStore.setState({ garment: { name: 'g', geometry: {} } as AnyAsset })
+    useTailorStore.setState({ pins: [{ vertex: 1, type: 'fixed', target: [0,0,0] }], isSimulating: true })
+    useCharacterStore.setState({ garment: null })
+    const tState = useTailorStore.getState()
+    expect(tState.pins).toHaveLength(0)
+    expect(tState.isSimulating).toBe(false)
+  })
+
   it('ignores uploads while loading', async () => {
     useCharacterStore.setState({ isLoading: true, garment: null, errors: [] })
     vi.clearAllMocks()

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three'
 import type { AnyAsset } from '../src/types'
 
 export function mockAsset(overrides: Partial<AnyAsset> = {}): AnyAsset {
-  const geometry = overrides.geometry ?? new THREE.BufferGeometry()
+  const geometry = overrides.geometry ?? overrides.mesh?.geometry ?? new THREE.BufferGeometry()
   return {
     name: 'mock',
     mesh: overrides.mesh ?? new THREE.SkinnedMesh(geometry),

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,15 @@
+import * as THREE from 'three'
+
+import type { AnyAsset } from '../src/types'
+
+export function mockAsset(overrides: Partial<AnyAsset> = {}): AnyAsset {
+  const geometry = overrides.geometry ?? new THREE.BufferGeometry()
+  return {
+    name: 'mock',
+    mesh: overrides.mesh ?? new THREE.SkinnedMesh(geometry),
+    geometry,
+    skeleton: overrides.skeleton ?? new THREE.Skeleton([]),
+    bindMatrix: overrides.bindMatrix ?? new THREE.Matrix4(),
+    ...overrides,
+  }
+}

--- a/tests/store.spec.ts
+++ b/tests/store.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 import { getMaterialSlotId } from '../src/lib/materials'
 import { useCharacterStore } from '../src/state/useCharacterStore'
-import type { AnyAsset } from '../src/types'
+import { mockAsset } from './helpers'
 
 describe('character store', () => {
   it('sets material assignment entries', () => {
@@ -21,8 +21,7 @@ describe('character store', () => {
       morphTargetsDictionary?: Record<string, number>
     }
     geom.morphTargetsDictionary = { A: 0, B: 1 }
-    const asset: AnyAsset = { geometry: geom } as unknown as AnyAsset
-    useCharacterStore.getState().refreshMorphKeys(asset)
+    useCharacterStore.getState().refreshMorphKeys(mockAsset({ geometry: geom }))
     const { morphKeys, morphWeights } = useCharacterStore.getState()
     expect(morphKeys).toEqual(['A', 'B'])
     expect(morphWeights).toEqual({ A: 0, B: 0 })
@@ -34,7 +33,7 @@ describe('character store', () => {
       materialAssign: { foo: 'head' },
       boneMap: { a: 'b' },
       headOffset: { position: { x: 1, y: 2, z: 3 }, rotation: { x: 0, y: 0, z: 0 }, scale: 1 },
-      base: { mesh: {} as unknown as THREE.Mesh } as unknown as AnyAsset,
+      base: mockAsset(),
     })
     const raw = localStorage.getItem('char-morphs')!
     const stored = JSON.parse(raw).state


### PR DESCRIPTION
## Summary
- reset pins and simulation whenever garment changes, including removal
- add test covering garment removal

## Testing
- `pnpm lint`
- `pnpm format:check`
- `pnpm test`
- `pnpm test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_689e9f81e5bc8322bda5cfdca505ca87